### PR TITLE
feat: implement OKR 017 — 4-layer service architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+**/node_modules
 /.pnp
 .pnp.js
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/kogeletey/kefine/issues/37
-Your prepared branch: issue-37-2bf1c95586b7
-Your prepared working directory: /tmp/gh-issue-solver-1771823327086
-Your forked repository: konard/kogeletey-kefine
-Original repository (upstream): kogeletey/kefine
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/kogeletey/kefine/issues/37
+Your prepared branch: issue-37-2bf1c95586b7
+Your prepared working directory: /tmp/gh-issue-solver-1771823327086
+Your forked repository: konard/kogeletey-kefine
+Original repository (upstream): kogeletey/kefine
+
+Proceed.

--- a/apps/simple-api/.env.example
+++ b/apps/simple-api/.env.example
@@ -1,0 +1,19 @@
+# Simple API configuration
+# Copy this file to .env and fill in the values
+
+# Server settings
+PORT=4000
+HOST=0.0.0.0
+NODE_ENV=development
+
+# CORS - comma-separated list of allowed origins
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3001
+
+# Logging
+LOG_LEVEL=info
+
+# Request timeout in milliseconds
+REQUEST_TIMEOUT_MS=30000
+
+# Security
+ENABLE_HELMET=true

--- a/apps/simple-api/package.json
+++ b/apps/simple-api/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@kefine/simple-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch --import tsx/esm src/index.ts",
+    "start": "node dist/index.js",
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@kefine/config": "workspace:*",
+    "@kefine/types": "workspace:*",
+    "express": "^4.21.0",
+    "cors": "^2.8.5",
+    "helmet": "^8.0.0",
+    "uuid": "^11.0.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.0.0",
+    "@types/uuid": "^10.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.8.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/apps/simple-api/src/index.ts
+++ b/apps/simple-api/src/index.ts
@@ -1,0 +1,41 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import { loadSimpleApiConfig } from '@kefine/config';
+import { taskRoutes } from './routes/tasks.js';
+import { healthRoutes } from './routes/health.js';
+import { errorHandler } from './middleware/error.js';
+import { requestLogger } from './middleware/logger.js';
+
+const config = loadSimpleApiConfig();
+
+const app = express();
+
+// Security headers
+if (config.enableHelmet) {
+  app.use(helmet());
+}
+
+// CORS
+app.use(cors({ origin: config.allowedOrigins }));
+
+// Body parsing
+app.use(express.json());
+
+// Request logging and ID injection
+app.use(requestLogger);
+
+// Routes
+app.use('/health', healthRoutes);
+app.use('/api/tasks', taskRoutes);
+
+// Error handling (must be last)
+app.use(errorHandler);
+
+// Start server
+app.listen(config.port, config.host, () => {
+  console.log(`Simple API running on http://${config.host}:${config.port}`);
+  console.log(`Environment: ${config.nodeEnv}`);
+});
+
+export default app;

--- a/apps/simple-api/src/middleware/error.ts
+++ b/apps/simple-api/src/middleware/error.ts
@@ -1,0 +1,51 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { RequestWithId } from './logger.js';
+
+export class ApiError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly status: number,
+    message: string,
+    public readonly details?: Record<string, string[]>
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export function errorHandler(
+  err: Error,
+  req: Request,
+  res: Response,
+  _next: NextFunction
+): void {
+  const requestId = (req as RequestWithId).requestId ?? 'unknown';
+
+  if (err instanceof ApiError) {
+    res.status(err.status).json({
+      error: {
+        code: err.code,
+        message: err.message,
+        details: err.details,
+      },
+      meta: {
+        requestId,
+        timestamp: new Date().toISOString(),
+      },
+    });
+    return;
+  }
+
+  console.error(`[${requestId}] Unhandled error:`, err);
+
+  res.status(500).json({
+    error: {
+      code: 'INTERNAL_ERROR',
+      message: 'An unexpected error occurred',
+    },
+    meta: {
+      requestId,
+      timestamp: new Date().toISOString(),
+    },
+  });
+}

--- a/apps/simple-api/src/middleware/logger.ts
+++ b/apps/simple-api/src/middleware/logger.ts
@@ -1,0 +1,24 @@
+import type { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'crypto';
+
+export interface RequestWithId extends Request {
+  requestId: string;
+}
+
+export function requestLogger(
+  req: RequestWithId,
+  _res: Response,
+  next: NextFunction
+): void {
+  req.requestId = randomUUID();
+  const start = Date.now();
+
+  console.log(`[${req.requestId}] ${req.method} ${req.path}`);
+
+  _res.on('finish', () => {
+    const duration = Date.now() - start;
+    console.log(`[${req.requestId}] ${_res.statusCode} - ${duration}ms`);
+  });
+
+  next();
+}

--- a/apps/simple-api/src/middleware/logger.ts
+++ b/apps/simple-api/src/middleware/logger.ts
@@ -6,18 +6,19 @@ export interface RequestWithId extends Request {
 }
 
 export function requestLogger(
-  req: RequestWithId,
+  req: Request,
   _res: Response,
   next: NextFunction
 ): void {
-  req.requestId = randomUUID();
+  (req as RequestWithId).requestId = randomUUID();
+  const requestId = (req as RequestWithId).requestId;
   const start = Date.now();
 
-  console.log(`[${req.requestId}] ${req.method} ${req.path}`);
+  console.log(`[${requestId}] ${req.method} ${req.path}`);
 
   _res.on('finish', () => {
     const duration = Date.now() - start;
-    console.log(`[${req.requestId}] ${_res.statusCode} - ${duration}ms`);
+    console.log(`[${requestId}] ${_res.statusCode} - ${duration}ms`);
   });
 
   next();

--- a/apps/simple-api/src/routes/health.ts
+++ b/apps/simple-api/src/routes/health.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json({
+    status: 'healthy',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime(),
+  });
+});
+
+router.get('/ready', (_req, res) => {
+  res.json({ ready: true });
+});
+
+router.get('/live', (_req, res) => {
+  res.json({ alive: true });
+});
+
+export { router as healthRoutes };

--- a/apps/simple-api/src/routes/tasks.ts
+++ b/apps/simple-api/src/routes/tasks.ts
@@ -53,7 +53,7 @@ router.get('/', async (req, res, next) => {
       priority,
     });
 
-    const typedReq = req as RequestWithId;
+    const typedReq = req as unknown as RequestWithId;
     result.meta.requestId = typedReq.requestId;
     res.json(result);
   } catch (error) {
@@ -70,7 +70,7 @@ router.get('/:id', async (req, res, next) => {
       throw new ApiError('NOT_FOUND', 404, 'Task not found');
     }
 
-    res.json({ data: task, meta: getRequestMeta(req as RequestWithId) });
+    res.json({ data: task, meta: getRequestMeta(req as unknown as RequestWithId) });
   } catch (error) {
     next(error);
   }
@@ -113,7 +113,7 @@ router.post('/', async (req, res, next) => {
 
     res.status(201).json({
       data: task,
-      meta: getRequestMeta(req as RequestWithId),
+      meta: getRequestMeta(req as unknown as RequestWithId),
     });
   } catch (error) {
     next(error);
@@ -153,7 +153,7 @@ router.put('/:id', async (req, res, next) => {
       throw new ApiError('NOT_FOUND', 404, 'Task not found');
     }
 
-    res.json({ data: task, meta: getRequestMeta(req as RequestWithId) });
+    res.json({ data: task, meta: getRequestMeta(req as unknown as RequestWithId) });
   } catch (error) {
     next(error);
   }

--- a/apps/simple-api/src/routes/tasks.ts
+++ b/apps/simple-api/src/routes/tasks.ts
@@ -1,0 +1,177 @@
+import { Router } from 'express';
+import type { CreateTaskRequest, TaskStatus, TaskPriority } from '@kefine/types';
+import { TaskService } from '../services/task.js';
+import { ApiError } from '../middleware/error.js';
+import type { RequestWithId } from '../middleware/logger.js';
+
+const router = Router();
+const taskService = new TaskService();
+
+const VALID_STATUSES: readonly TaskStatus[] = ['todo', 'in_progress', 'done', 'blocked'];
+const VALID_PRIORITIES: readonly TaskPriority[] = ['low', 'medium', 'high', 'critical'];
+
+function isValidStatus(s: string): s is TaskStatus {
+  return (VALID_STATUSES as readonly string[]).includes(s);
+}
+
+function isValidPriority(p: string): p is TaskPriority {
+  return (VALID_PRIORITIES as readonly string[]).includes(p);
+}
+
+function getRequestMeta(req: RequestWithId) {
+  return {
+    requestId: req.requestId,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// GET /api/tasks
+router.get('/', async (req, res, next) => {
+  try {
+    const { page = '1', pageSize = '20', status, priority } = req.query as Record<string, string | undefined>;
+
+    const parsedPage = parseInt(page, 10);
+    const parsedPageSize = parseInt(pageSize, 10);
+
+    if (isNaN(parsedPage) || parsedPage < 1) {
+      throw new ApiError('VALIDATION_ERROR', 400, 'page must be a positive integer');
+    }
+    if (isNaN(parsedPageSize) || parsedPageSize < 1 || parsedPageSize > 100) {
+      throw new ApiError('VALIDATION_ERROR', 400, 'pageSize must be between 1 and 100');
+    }
+    if (status !== undefined && !isValidStatus(status)) {
+      throw new ApiError('VALIDATION_ERROR', 400, `status must be one of: ${VALID_STATUSES.join(', ')}`);
+    }
+    if (priority !== undefined && !isValidPriority(priority)) {
+      throw new ApiError('VALIDATION_ERROR', 400, `priority must be one of: ${VALID_PRIORITIES.join(', ')}`);
+    }
+
+    const result = await taskService.list({
+      page: parsedPage,
+      pageSize: parsedPageSize,
+      status,
+      priority,
+    });
+
+    const typedReq = req as RequestWithId;
+    result.meta.requestId = typedReq.requestId;
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/tasks/:id
+router.get('/:id', async (req, res, next) => {
+  try {
+    const task = await taskService.getById(req.params.id);
+
+    if (task === undefined) {
+      throw new ApiError('NOT_FOUND', 404, 'Task not found');
+    }
+
+    res.json({ data: task, meta: getRequestMeta(req as RequestWithId) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/tasks
+router.post('/', async (req, res, next) => {
+  try {
+    const body = req.body as Record<string, unknown>;
+
+    if (typeof body.title !== 'string' || body.title.trim() === '') {
+      throw new ApiError('VALIDATION_ERROR', 400, 'title is required and must be a non-empty string');
+    }
+
+    if (body.status !== undefined && !isValidStatus(body.status as string)) {
+      throw new ApiError('VALIDATION_ERROR', 400, `status must be one of: ${VALID_STATUSES.join(', ')}`);
+    }
+
+    if (body.priority !== undefined && !isValidPriority(body.priority as string)) {
+      throw new ApiError('VALIDATION_ERROR', 400, `priority must be one of: ${VALID_PRIORITIES.join(', ')}`);
+    }
+
+    const createData: CreateTaskRequest = {
+      title: (body.title as string).trim(),
+      description: typeof body.description === 'string' ? body.description : undefined,
+      status: body.status as TaskStatus | undefined,
+      priority: body.priority as TaskPriority | undefined,
+      assigneeId: typeof body.assigneeId === 'string' ? body.assigneeId : undefined,
+      projectId: typeof body.projectId === 'string' ? body.projectId : undefined,
+      parentTaskId: typeof body.parentTaskId === 'string' ? body.parentTaskId : undefined,
+      tags: Array.isArray(body.tags) ? (body.tags as string[]) : undefined,
+      dueDate: typeof body.dueDate === 'string' ? body.dueDate : undefined,
+      estimatedHours: typeof body.estimatedHours === 'number' ? body.estimatedHours : undefined,
+      metadata: typeof body.metadata === 'object' && body.metadata !== null
+        ? (body.metadata as Record<string, unknown>)
+        : undefined,
+    };
+
+    const task = await taskService.create(createData);
+
+    res.status(201).json({
+      data: task,
+      meta: getRequestMeta(req as RequestWithId),
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PUT /api/tasks/:id
+router.put('/:id', async (req, res, next) => {
+  try {
+    const body = req.body as Record<string, unknown>;
+
+    if (body.status !== undefined && !isValidStatus(body.status as string)) {
+      throw new ApiError('VALIDATION_ERROR', 400, `status must be one of: ${VALID_STATUSES.join(', ')}`);
+    }
+
+    if (body.priority !== undefined && !isValidPriority(body.priority as string)) {
+      throw new ApiError('VALIDATION_ERROR', 400, `priority must be one of: ${VALID_PRIORITIES.join(', ')}`);
+    }
+
+    const task = await taskService.update(req.params.id, {
+      title: typeof body.title === 'string' ? body.title.trim() : undefined,
+      description: typeof body.description === 'string' ? body.description : undefined,
+      status: body.status as TaskStatus | undefined,
+      priority: body.priority as TaskPriority | undefined,
+      assigneeId: typeof body.assigneeId === 'string' ? body.assigneeId : undefined,
+      projectId: typeof body.projectId === 'string' ? body.projectId : undefined,
+      parentTaskId: typeof body.parentTaskId === 'string' ? body.parentTaskId : undefined,
+      tags: Array.isArray(body.tags) ? (body.tags as string[]) : undefined,
+      dueDate: typeof body.dueDate === 'string' ? body.dueDate : undefined,
+      estimatedHours: typeof body.estimatedHours === 'number' ? body.estimatedHours : undefined,
+      metadata: typeof body.metadata === 'object' && body.metadata !== null
+        ? (body.metadata as Record<string, unknown>)
+        : undefined,
+    });
+
+    if (task === undefined) {
+      throw new ApiError('NOT_FOUND', 404, 'Task not found');
+    }
+
+    res.json({ data: task, meta: getRequestMeta(req as RequestWithId) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// DELETE /api/tasks/:id
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const deleted = await taskService.delete(req.params.id);
+
+    if (!deleted) {
+      throw new ApiError('NOT_FOUND', 404, 'Task not found');
+    }
+
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export { router as taskRoutes };

--- a/apps/simple-api/src/services/task.ts
+++ b/apps/simple-api/src/services/task.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from 'crypto';
+import type { Task, CreateTaskRequest, UpdateTaskRequest, ListResponse } from '@kefine/types';
+
+interface ListOptions {
+  page: number;
+  pageSize: number;
+  status?: string;
+  priority?: string;
+}
+
+export class TaskService {
+  private readonly tasks: Map<string, Task> = new Map();
+
+  async list(options: ListOptions): Promise<ListResponse<Task>> {
+    let items = Array.from(this.tasks.values());
+
+    if (options.status !== undefined) {
+      items = items.filter((t) => t.status === options.status);
+    }
+
+    if (options.priority !== undefined) {
+      items = items.filter((t) => t.priority === options.priority);
+    }
+
+    const total = items.length;
+    const start = (options.page - 1) * options.pageSize;
+    const paginated = items.slice(start, start + options.pageSize);
+
+    return {
+      data: paginated,
+      meta: {
+        total,
+        page: options.page,
+        pageSize: options.pageSize,
+        totalPages: Math.ceil(total / options.pageSize),
+        requestId: '',
+        timestamp: new Date().toISOString(),
+      },
+    };
+  }
+
+  async getById(id: string): Promise<Task | undefined> {
+    return this.tasks.get(id);
+  }
+
+  async create(data: CreateTaskRequest): Promise<Task> {
+    const now = new Date().toISOString();
+    const task: Task = {
+      id: randomUUID(),
+      title: data.title,
+      description: data.description,
+      status: data.status ?? 'todo',
+      priority: data.priority ?? 'medium',
+      assigneeId: data.assigneeId,
+      projectId: data.projectId,
+      parentTaskId: data.parentTaskId,
+      tags: data.tags ?? [],
+      dueDate: data.dueDate,
+      estimatedHours: data.estimatedHours,
+      metadata: data.metadata,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.tasks.set(task.id, task);
+    return task;
+  }
+
+  async update(id: string, updates: UpdateTaskRequest): Promise<Task | undefined> {
+    const task = this.tasks.get(id);
+    if (task === undefined) return undefined;
+
+    const updated: Task = {
+      ...task,
+      ...updates,
+      tags: updates.tags ?? task.tags,
+      updatedAt: new Date().toISOString(),
+    };
+    this.tasks.set(id, updated);
+    return updated;
+  }
+
+  async delete(id: string): Promise<boolean> {
+    return this.tasks.delete(id);
+  }
+}

--- a/apps/simple-api/src/tests/task-service.test.ts
+++ b/apps/simple-api/src/tests/task-service.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { TaskService } from '../services/task.js';
+
+describe('TaskService', () => {
+  it('creates a task with defaults', async () => {
+    const service = new TaskService();
+    const task = await service.create({ title: 'Test Task' });
+
+    expect(task.id).toBeTruthy();
+    expect(task.title).toBe('Test Task');
+    expect(task.status).toBe('todo');
+    expect(task.priority).toBe('medium');
+    expect(task.tags).toEqual([]);
+    expect(task.createdAt).toBeTruthy();
+    expect(task.updatedAt).toBeTruthy();
+  });
+
+  it('creates a task with custom fields', async () => {
+    const service = new TaskService();
+    const task = await service.create({
+      title: 'Bug Fix',
+      status: 'in_progress',
+      priority: 'high',
+      tags: ['backend', 'critical'],
+    });
+
+    expect(task.status).toBe('in_progress');
+    expect(task.priority).toBe('high');
+    expect(task.tags).toEqual(['backend', 'critical']);
+  });
+
+  it('retrieves a task by id', async () => {
+    const service = new TaskService();
+    const created = await service.create({ title: 'Find Me' });
+    const found = await service.getById(created.id);
+
+    expect(found).toBeDefined();
+    expect(found?.title).toBe('Find Me');
+  });
+
+  it('returns undefined for missing task id', async () => {
+    const service = new TaskService();
+    const found = await service.getById('nonexistent-id');
+    expect(found).toBeUndefined();
+  });
+
+  it('lists tasks with pagination', async () => {
+    const service = new TaskService();
+    for (let i = 0; i < 5; i++) {
+      await service.create({ title: `Task ${i}` });
+    }
+
+    const page1 = await service.list({ page: 1, pageSize: 3 });
+    expect(page1.data).toHaveLength(3);
+    expect(page1.meta.total).toBe(5);
+    expect(page1.meta.totalPages).toBe(2);
+
+    const page2 = await service.list({ page: 2, pageSize: 3 });
+    expect(page2.data).toHaveLength(2);
+  });
+
+  it('filters tasks by status', async () => {
+    const service = new TaskService();
+    await service.create({ title: 'Todo Task', status: 'todo' });
+    await service.create({ title: 'Done Task', status: 'done' });
+
+    const result = await service.list({ page: 1, pageSize: 20, status: 'done' });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]?.title).toBe('Done Task');
+  });
+
+  it('filters tasks by priority', async () => {
+    const service = new TaskService();
+    await service.create({ title: 'Low Task', priority: 'low' });
+    await service.create({ title: 'High Task', priority: 'high' });
+
+    const result = await service.list({ page: 1, pageSize: 20, priority: 'high' });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]?.title).toBe('High Task');
+  });
+
+  it('updates a task', async () => {
+    const service = new TaskService();
+    const task = await service.create({ title: 'Original' });
+    const updated = await service.update(task.id, { title: 'Updated', status: 'done' });
+
+    expect(updated).toBeDefined();
+    expect(updated?.title).toBe('Updated');
+    expect(updated?.status).toBe('done');
+    expect(updated?.updatedAt).not.toBe(task.updatedAt);
+  });
+
+  it('returns undefined when updating non-existent task', async () => {
+    const service = new TaskService();
+    const result = await service.update('nonexistent', { title: 'New' });
+    expect(result).toBeUndefined();
+  });
+
+  it('deletes a task', async () => {
+    const service = new TaskService();
+    const task = await service.create({ title: 'Delete Me' });
+    const deleted = await service.delete(task.id);
+
+    expect(deleted).toBe(true);
+    expect(await service.getById(task.id)).toBeUndefined();
+  });
+
+  it('returns false when deleting non-existent task', async () => {
+    const service = new TaskService();
+    const result = await service.delete('nonexistent');
+    expect(result).toBe(false);
+  });
+});

--- a/apps/simple-api/tsconfig.json
+++ b/apps/simple-api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,42 @@
         "vite": "^6.2.0",
       },
     },
+    "apps/simple-api": {
+      "name": "@kefine/simple-api",
+      "version": "0.1.0",
+      "dependencies": {
+        "@kefine/config": "workspace:*",
+        "@kefine/types": "workspace:*",
+        "cors": "^2.8.5",
+        "express": "^4.21.0",
+        "helmet": "^8.0.0",
+        "uuid": "^11.0.0",
+      },
+      "devDependencies": {
+        "@types/cors": "^2.8.17",
+        "@types/express": "^5.0.0",
+        "@types/node": "^22.0.0",
+        "@types/uuid": "^10.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.8.0",
+        "vitest": "^3.0.0",
+      },
+    },
+    "packages/config": {
+      "name": "@kefine/config",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^25.3.0",
+        "typescript": "^5.8.0",
+      },
+    },
+    "packages/types": {
+      "name": "@kefine/types",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^5.8.0",
+      },
+    },
   },
   "packages": {
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
@@ -78,6 +114,12 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@kefine/config": ["@kefine/config@workspace:packages/config"],
+
+    "@kefine/simple-api": ["@kefine/simple-api@workspace:apps/simple-api"],
+
+    "@kefine/types": ["@kefine/types@workspace:packages/types"],
 
     "@oxlint/darwin-arm64": ["@oxlint/darwin-arm64@0.15.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7GOyGM6D36lUhsOvavAVpF72SycPVG0Enunx0bzv8g0+9TklzOSFN3FJlZjLst14VPdZWujZMLgkQC7tOp+Rwg=="],
 
@@ -159,49 +201,197 @@
 
     "@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@4.0.1", "", { "dependencies": { "debug": "^4.3.7" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^5.0.0", "svelte": "^5.0.0", "vite": "^6.0.0" } }, "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw=="],
 
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
+
+    "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+
+    "@types/qs": ["@types/qs@6.14.0", "", {}, "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
+
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
+
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
+
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
+    "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "body-parser": ["body-parser@1.20.4", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.14.0", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
+
+    "cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
     "devalue": ["devalue@5.6.3", "", {}, "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
 
     "esrap": ["esrap@2.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "express": ["express@4.22.1", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.3", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.14.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "finalhandler": ["finalhandler@1.3.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "statuses": "~2.0.2", "unpipe": "~1.0.0" } }, "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "helmet": ["helmet@8.1.0", "", {}, "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
     "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
+
+    "merge-descriptors": ["merge-descriptors@1.0.3", "", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
+
+    "methods": ["methods@1.1.2", "", {}, "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="],
+
+    "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -211,7 +401,23 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
     "oxlint": ["oxlint@0.15.15", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "0.15.15", "@oxlint/darwin-x64": "0.15.15", "@oxlint/linux-arm64-gnu": "0.15.15", "@oxlint/linux-arm64-musl": "0.15.15", "@oxlint/linux-x64-gnu": "0.15.15", "@oxlint/linux-x64-musl": "0.15.15", "@oxlint/win32-arm64": "0.15.15", "@oxlint/win32-x64": "0.15.15" }, "bin": { "oxlint": "bin/oxlint", "oxc_language_server": "bin/oxc_language_server" } }, "sha512-oQNc1mAHrrbKiXyKJMGs9VCZfwGfLy7YiQKa4qupi71X/u4xyWqOh36YKXqWOXnmm2y7vfWFpGZlhJPAa9tMqA=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-to-regexp": ["path-to-regexp@0.1.12", "", {}, "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -219,32 +425,178 @@
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.14.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
+
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
+
+    "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
+
     "set-cookie-parser": ["set-cookie-parser@3.0.1", "", {}, "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
     "svelte": ["svelte@5.53.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.3", "esm-env": "^1.2.1", "esrap": "^2.2.2", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-yGONuIrcl/BMmqbm6/52Q/NYzfkta7uVlos5NSzGTfNJTTFtPPzra6rAQoQIwAqupeM3s9uuTf5PvioeiCdg9g=="],
 
     "svelte-check": ["svelte-check@4.4.3", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-4HtdEv2hOoLCEsSXI+RDELk9okP/4sImWa7X02OjMFFOWeSdFF3NFy3vqpw0z+eH9C88J9vxZfUXz/Uv2A1ANw=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
+
+    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
     "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
 
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
+
+    "@kefine/simple-api/@types/node": ["@types/node@22.19.11", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w=="],
+
+    "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "tsx/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "@kefine/simple-api/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -11,6 +11,7 @@
     "check": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/node": "^25.3.0",
     "typescript": "^5.8.0"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@kefine/config",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/config/src/crater.ts
+++ b/packages/config/src/crater.ts
@@ -1,0 +1,28 @@
+// Configuration schema and defaults for the Crater proxy service
+import { optionalEnv, optionalEnvInt } from './env.js';
+
+export interface CraterConfig {
+  port: number;
+  host: string;
+  nodeEnv: string;
+  simpleApiUrl: string;
+  domain: string;
+  actorUsername: string;
+  logLevel: string;
+}
+
+/**
+ * Load Crater proxy configuration from environment variables.
+ * All values have sensible defaults for local development.
+ */
+export function loadCraterConfig(env: Record<string, string | undefined> = process.env): CraterConfig {
+  return {
+    port: optionalEnvInt('PORT', 3001, env),
+    host: optionalEnv('HOST', '0.0.0.0', env),
+    nodeEnv: optionalEnv('NODE_ENV', 'development', env),
+    simpleApiUrl: optionalEnv('SIMPLE_API_URL', 'http://localhost:4000', env),
+    domain: optionalEnv('DOMAIN', 'localhost:3001', env),
+    actorUsername: optionalEnv('ACTOR_USERNAME', 'crater', env),
+    logLevel: optionalEnv('LOG_LEVEL', 'info', env),
+  };
+}

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -1,0 +1,46 @@
+// Environment variable loader utility
+// Reads from process.env and provides typed access
+
+export type Env = Record<string, string | undefined>;
+
+/**
+ * Get a required environment variable.
+ * Returns the value or throws a descriptive error if not set.
+ */
+export function requireEnv(key: string, env: Env = process.env): string {
+  const value = env[key];
+  if (value === undefined || value === '') {
+    throw new Error(`Required environment variable "${key}" is not set`);
+  }
+  return value;
+}
+
+/**
+ * Get an optional environment variable with a default value.
+ */
+export function optionalEnv(key: string, defaultValue: string, env: Env = process.env): string {
+  return env[key] ?? defaultValue;
+}
+
+/**
+ * Get an optional numeric environment variable with a default value.
+ */
+export function optionalEnvInt(key: string, defaultValue: number, env: Env = process.env): number {
+  const raw = env[key];
+  if (raw === undefined || raw === '') return defaultValue;
+  const parsed = parseInt(raw, 10);
+  if (isNaN(parsed)) {
+    throw new Error(`Environment variable "${key}" must be an integer, got: "${raw}"`);
+  }
+  return parsed;
+}
+
+/**
+ * Get an optional boolean environment variable with a default value.
+ * Truthy values: "true", "1", "yes"
+ */
+export function optionalEnvBool(key: string, defaultValue: boolean, env: Env = process.env): boolean {
+  const raw = env[key];
+  if (raw === undefined || raw === '') return defaultValue;
+  return raw === 'true' || raw === '1' || raw === 'yes';
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,4 @@
+// @kefine/config - Configuration management for Kefine services
+export * from './env.js';
+export * from './simple-api.js';
+export * from './crater.js';

--- a/packages/config/src/simple-api.ts
+++ b/packages/config/src/simple-api.ts
@@ -1,0 +1,31 @@
+// Configuration schema and defaults for the Simple API service
+import { optionalEnv, optionalEnvInt, optionalEnvBool } from './env.js';
+
+export interface SimpleApiConfig {
+  port: number;
+  host: string;
+  nodeEnv: string;
+  allowedOrigins: string[];
+  logLevel: string;
+  requestTimeout: number;
+  enableHelmet: boolean;
+}
+
+/**
+ * Load Simple API configuration from environment variables.
+ * All values have sensible defaults for local development.
+ */
+export function loadSimpleApiConfig(env: Record<string, string | undefined> = process.env): SimpleApiConfig {
+  const originsRaw = optionalEnv('ALLOWED_ORIGINS', 'http://localhost:5173', env);
+  const allowedOrigins = originsRaw.split(',').map((o) => o.trim()).filter(Boolean);
+
+  return {
+    port: optionalEnvInt('PORT', 4000, env),
+    host: optionalEnv('HOST', '0.0.0.0', env),
+    nodeEnv: optionalEnv('NODE_ENV', 'development', env),
+    allowedOrigins,
+    logLevel: optionalEnv('LOG_LEVEL', 'info', env),
+    requestTimeout: optionalEnvInt('REQUEST_TIMEOUT_MS', 30000, env),
+    enableHelmet: optionalEnvBool('ENABLE_HELMET', true, env),
+  };
+}

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "bundler",
     "strict": true,
     "noEmit": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@kefine/types",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1,0 +1,42 @@
+// Shared API response types
+export interface ApiMeta {
+  requestId: string;
+  timestamp: string;
+}
+
+export interface ApiResponse<T> {
+  data: T;
+  meta: ApiMeta;
+}
+
+export interface ListMeta extends ApiMeta {
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export interface ListLinks {
+  self: string;
+  first: string;
+  last: string;
+  next?: string;
+  prev?: string;
+}
+
+export interface ListResponse<T> {
+  data: T[];
+  meta: ListMeta;
+  links?: ListLinks;
+}
+
+export interface ApiErrorDetail {
+  code: string;
+  message: string;
+  details?: Record<string, string[]>;
+}
+
+export interface ApiErrorResponse {
+  error: ApiErrorDetail;
+  meta: ApiMeta;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,5 @@
+// @kefine/types - Shared type definitions
+export * from './task.js';
+export * from './project.js';
+export * from './user.js';
+export * from './api.js';

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -1,0 +1,25 @@
+// Project types shared across services
+export interface Project {
+  id: string;
+  name: string;
+  summary?: string;
+  description?: string;
+  sourceRepository?: string;
+  issueTracker?: string;
+  administrators: string[];
+  createdAt: string;
+  updatedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateProjectRequest {
+  name: string;
+  summary?: string;
+  description?: string;
+  sourceRepository?: string;
+  issueTracker?: string;
+  administrators?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export type UpdateProjectRequest = Partial<CreateProjectRequest>;

--- a/packages/types/src/task.ts
+++ b/packages/types/src/task.ts
@@ -1,0 +1,37 @@
+// Task types shared across services
+export type TaskStatus = 'todo' | 'in_progress' | 'done' | 'blocked';
+export type TaskPriority = 'low' | 'medium' | 'high' | 'critical';
+
+export interface Task {
+  id: string;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  assigneeId?: string;
+  projectId?: string;
+  parentTaskId?: string;
+  tags: string[];
+  dueDate?: string;
+  estimatedHours?: number;
+  actualHours?: number;
+  createdAt: string;
+  updatedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateTaskRequest {
+  title: string;
+  description?: string;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  assigneeId?: string;
+  projectId?: string;
+  parentTaskId?: string;
+  tags?: string[];
+  dueDate?: string;
+  estimatedHours?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export type UpdateTaskRequest = Partial<CreateTaskRequest>;

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -1,0 +1,21 @@
+// User types shared across services
+export interface User {
+  id: string;
+  username: string;
+  displayName?: string;
+  email?: string;
+  avatarUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateUserRequest {
+  username: string;
+  displayName?: string;
+  email?: string;
+  avatarUrl?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type UpdateUserRequest = Partial<CreateUserRequest>;

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/services/crater/.env.example
+++ b/services/crater/.env.example
@@ -1,0 +1,19 @@
+# Crater proxy configuration
+# Copy this file to .env and fill in the values
+
+# Server settings
+PORT=3001
+HOST=0.0.0.0
+CRYSTAL_ENV=development
+
+# URL of the internal Simple API service
+SIMPLE_API_URL=http://localhost:4000
+
+# Public domain name for ActivityPub actor URLs
+DOMAIN=localhost:3001
+
+# Username for the Crater ActivityPub actor
+ACTOR_USERNAME=crater
+
+# Logging
+LOG_LEVEL=info

--- a/services/crater/shard.yml
+++ b/services/crater/shard.yml
@@ -1,0 +1,23 @@
+name: crater
+version: 0.1.0
+
+authors:
+  - Kefine Team
+
+description: |
+  Crater is the ForgeFed/ActivityPub proxy service for Kefine.
+  It acts as Layer 1 (Proxy Service Layer) in the 4-layer architecture,
+  translating between the Kefine frontend and external federation servers.
+
+targets:
+  crater:
+    main: src/crater.cr
+
+dependencies:
+  kemal:
+    github: kemalcr/kemal
+    version: "~> 1.6.0"
+
+crystal: ">= 1.10.0"
+
+license: MIT

--- a/services/crater/src/crater.cr
+++ b/services/crater/src/crater.cr
@@ -1,0 +1,47 @@
+require "kemal"
+require "./crater/activitypub/types"
+require "./crater/forgefed/types"
+require "./crater/handlers/webfinger"
+require "./crater/handlers/nodeinfo"
+require "./crater/handlers/actor"
+require "./crater/handlers/inbox"
+require "./crater/handlers/outbox"
+require "./crater/handlers/projects"
+require "./crater/handlers/tasks"
+require "./crater/middleware/cors"
+require "./crater/middleware/logger"
+require "./crater/utils/config"
+
+module Crater
+  VERSION = "0.1.0"
+
+  def self.run
+    config = Utils::Config.load
+
+    # Middleware
+    add_handler CorsHandler.new
+    add_handler RequestLogger.new
+
+    # ActivityPub discovery
+    Handlers::WebFinger.register(config)
+    Handlers::NodeInfo.register(config)
+    Handlers::Actor.register(config)
+
+    # ActivityPub inbox/outbox
+    Handlers::Inbox.register(config)
+    Handlers::Outbox.register(config)
+
+    # ForgeFed project endpoints
+    Handlers::Projects.register(config)
+
+    # Task proxy endpoints (to Simple API)
+    Handlers::Tasks.register(config)
+
+    Kemal.config.port = config.port
+    Kemal.config.host_binding = config.host
+
+    Kemal.run
+  end
+end
+
+Crater.run

--- a/services/crater/src/crater/activitypub/types.cr
+++ b/services/crater/src/crater/activitypub/types.cr
@@ -1,0 +1,91 @@
+require "json"
+
+module Crater
+  module ActivityPub
+    CONTEXT        = "https://www.w3.org/ns/activitystreams"
+    SECURITY_CONTEXT = "https://w3id.org/security/v1"
+
+    struct Activity
+      include JSON::Serializable
+
+      @[JSON::Field(key: "@context")]
+      getter context : JSON::Any
+
+      getter id : String
+      getter type : String
+      getter actor : String
+      getter object : JSON::Any
+      getter published : String?
+      getter to : Array(String)?
+      getter cc : Array(String)?
+    end
+
+    struct PublicKey
+      include JSON::Serializable
+
+      getter id : String
+      getter owner : String
+
+      @[JSON::Field(key: "publicKeyPem")]
+      getter public_key_pem : String
+    end
+
+    struct Endpoints
+      include JSON::Serializable
+
+      @[JSON::Field(key: "sharedInbox")]
+      getter shared_inbox : String?
+    end
+
+    struct Actor
+      include JSON::Serializable
+
+      @[JSON::Field(key: "@context")]
+      getter context : Array(String)
+
+      getter id : String
+      getter type : String
+      getter name : String
+
+      @[JSON::Field(key: "preferredUsername")]
+      getter preferred_username : String
+
+      getter inbox : String
+      getter outbox : String
+      getter endpoints : Endpoints?
+
+      @[JSON::Field(key: "publicKey")]
+      getter public_key : PublicKey
+    end
+
+    struct OrderedCollection
+      include JSON::Serializable
+
+      @[JSON::Field(key: "@context")]
+      getter context : String
+
+      getter id : String
+      getter type : String
+
+      @[JSON::Field(key: "totalItems")]
+      getter total_items : Int32
+
+      @[JSON::Field(key: "orderedItems")]
+      getter ordered_items : Array(JSON::Any)
+
+      getter first : String?
+      getter last : String?
+
+      def initialize(
+        @id : String,
+        @total_items : Int32,
+        @ordered_items : Array(JSON::Any) = [] of JSON::Any,
+        @first : String? = nil,
+        @last : String? = nil
+      )
+        @context = CONTEXT
+        @type = "OrderedCollection"
+      end
+    end
+  end
+end

--- a/services/crater/src/crater/forgefed/types.cr
+++ b/services/crater/src/crater/forgefed/types.cr
@@ -1,0 +1,91 @@
+require "json"
+require "time"
+
+module Crater
+  module ForgeFed
+    CONTEXT = "https://forgefed.org/ns"
+
+    struct Project
+      include JSON::Serializable
+
+      @[JSON::Field(key: "@context")]
+      getter context : Array(String)
+
+      getter id : String
+      getter type : String
+      getter name : String
+      getter summary : String?
+      getter description : String?
+
+      @[JSON::Field(key: "sourceRepository")]
+      getter source_repository : String?
+
+      @[JSON::Field(key: "issueTracker")]
+      getter issue_tracker : String?
+
+      getter administrators : Array(String)
+
+      @[JSON::Field(key: "createdAt")]
+      getter created_at : String
+
+      @[JSON::Field(key: "updatedAt")]
+      getter updated_at : String
+
+      def initialize(
+        @id : String,
+        @name : String,
+        @administrators : Array(String),
+        @summary : String? = nil,
+        @description : String? = nil,
+        @source_repository : String? = nil,
+        @issue_tracker : String? = nil
+      )
+        now = Time.utc.to_s
+        @context = [ActivityPub::CONTEXT, CONTEXT]
+        @type = "Project"
+        @created_at = now
+        @updated_at = now
+      end
+    end
+
+    struct Ticket
+      include JSON::Serializable
+
+      @[JSON::Field(key: "@context")]
+      getter context : Array(String)
+
+      getter id : String
+      getter type : String
+      getter name : String
+      getter content : String?
+      getter status : String
+      getter priority : String?
+      getter reporter : String
+      getter assignee : String?
+      getter labels : Array(String)
+
+      @[JSON::Field(key: "createdAt")]
+      getter created_at : String
+
+      @[JSON::Field(key: "updatedAt")]
+      getter updated_at : String
+
+      def initialize(
+        @id : String,
+        @name : String,
+        @reporter : String,
+        @content : String? = nil,
+        @status : String = "open",
+        @priority : String? = nil,
+        @assignee : String? = nil,
+        @labels : Array(String) = [] of String
+      )
+        now = Time.utc.to_s
+        @context = [ActivityPub::CONTEXT, CONTEXT]
+        @type = "Ticket"
+        @created_at = now
+        @updated_at = now
+      end
+    end
+  end
+end

--- a/services/crater/src/crater/handlers/actor.cr
+++ b/services/crater/src/crater/handlers/actor.cr
@@ -1,0 +1,49 @@
+require "kemal"
+require "json"
+require "../activitypub/types"
+require "../utils/config"
+
+module Crater
+  module Handlers
+    module Actor
+      def self.register(config : Utils::Config)
+        get "/actor" do |env|
+          env.response.content_type = "application/activity+json"
+
+          {
+            "@context" => [
+              ActivityPub::CONTEXT,
+              ActivityPub::SECURITY_CONTEXT,
+            ],
+            "id"                => config.actor_id,
+            "type"              => "Application",
+            "preferredUsername" => config.actor_username,
+            "name"              => "Crater Proxy",
+            "summary"           => "Kefine ForgeFed/ActivityPub proxy service",
+            "inbox"             => config.actor_inbox,
+            "outbox"            => config.actor_outbox,
+            "endpoints"         => {
+              "sharedInbox" => config.actor_inbox,
+            },
+            "publicKey" => {
+              "id"           => "#{config.actor_id}#main-key",
+              "owner"        => config.actor_id,
+              "publicKeyPem" => "",
+            },
+          }.to_json
+        end
+
+        get "/u/:username" do |env|
+          username = env.params.url["username"]
+          if username == config.actor_username
+            env.response.status_code = 302
+            env.response.headers["Location"] = config.actor_id
+          else
+            env.response.status_code = 404
+            {error: "Actor not found"}.to_json
+          end
+        end
+      end
+    end
+  end
+end

--- a/services/crater/src/crater/handlers/inbox.cr
+++ b/services/crater/src/crater/handlers/inbox.cr
@@ -1,0 +1,36 @@
+require "kemal"
+require "json"
+require "../activitypub/types"
+require "../utils/config"
+
+module Crater
+  module Handlers
+    module Inbox
+      ACCEPTED_TYPES = %w[Create Update Delete Follow Accept Reject]
+
+      def self.register(config : Utils::Config)
+        post "/inbox" do |env|
+          body = env.request.body.try(&.gets_to_end) || ""
+
+          activity = begin
+            ActivityPub::Activity.from_json(body)
+          rescue JSON::ParseException
+            env.response.status_code = 400
+            next({error: "Invalid JSON body"}.to_json)
+          end
+
+          unless ACCEPTED_TYPES.includes?(activity.type)
+            env.response.status_code = 400
+            next({error: "Unknown activity type: #{activity.type}"}.to_json)
+          end
+
+          # TODO: Verify HTTP Signature before processing
+          # TODO: Forward relevant activities to Simple API
+
+          env.response.status_code = 202
+          {accepted: true, type: activity.type}.to_json
+        end
+      end
+    end
+  end
+end

--- a/services/crater/src/crater/handlers/nodeinfo.cr
+++ b/services/crater/src/crater/handlers/nodeinfo.cr
@@ -1,0 +1,43 @@
+require "kemal"
+require "json"
+require "../utils/config"
+
+module Crater
+  module Handlers
+    module NodeInfo
+      def self.register(config : Utils::Config)
+        get "/.well-known/nodeinfo" do |env|
+          env.response.content_type = "application/json"
+
+          {
+            links: [
+              {
+                rel:  "http://nodeinfo.diaspora.software/ns/schema/2.0",
+                href: "http://#{config.domain}/nodeinfo/2.0",
+              },
+            ],
+          }.to_json
+        end
+
+        get "/nodeinfo/2.0" do |env|
+          env.response.content_type = "application/json; profile=\"http://nodeinfo.diaspora.software/ns/schema/2.0#\""
+
+          {
+            version:  "2.0",
+            software: {
+              name:    "Crater",
+              version: Crater::VERSION,
+            },
+            protocols:         ["activitypub", "forgefed"],
+            services:          {inbound: [] of String, outbound: [] of String},
+            usage:             {
+              users:      {total: 0, activeMonth: 0, activeHalfyear: 0},
+              localPosts: 0,
+            },
+            openRegistrations: false,
+          }.to_json
+        end
+      end
+    end
+  end
+end

--- a/services/crater/src/crater/handlers/outbox.cr
+++ b/services/crater/src/crater/handlers/outbox.cr
@@ -1,0 +1,36 @@
+require "kemal"
+require "json"
+require "../activitypub/types"
+require "../utils/config"
+
+module Crater
+  module Handlers
+    module Outbox
+      def self.register(config : Utils::Config)
+        get "/outbox" do |env|
+          env.response.content_type = "application/activity+json"
+
+          page = env.params.query["page"]?
+
+          if page
+            {
+              "@context"    => ActivityPub::CONTEXT,
+              "id"          => "#{config.actor_outbox}?page=#{page}",
+              "type"        => "OrderedCollectionPage",
+              "orderedItems" => [] of JSON::Any,
+              "partOf"      => config.actor_outbox,
+            }.to_json
+          else
+            {
+              "@context"   => ActivityPub::CONTEXT,
+              "id"         => config.actor_outbox,
+              "type"       => "OrderedCollection",
+              "totalItems" => 0,
+              "first"      => "#{config.actor_outbox}?page=1",
+            }.to_json
+          end
+        end
+      end
+    end
+  end
+end

--- a/services/crater/src/crater/handlers/projects.cr
+++ b/services/crater/src/crater/handlers/projects.cr
@@ -1,0 +1,55 @@
+require "kemal"
+require "json"
+require "../forgefed/types"
+require "../utils/config"
+
+module Crater
+  module Handlers
+    module Projects
+      def self.register(config : Utils::Config)
+        get "/projects" do |env|
+          env.response.content_type = "application/json"
+
+          # TODO: Proxy to Simple API and transform to ForgeFed Project format
+          {
+            data: [] of JSON::Any,
+            meta: {
+              total:      0,
+              page:       1,
+              pageSize:   20,
+              totalPages: 0,
+              timestamp:  Time.utc.to_s,
+            },
+          }.to_json
+        end
+
+        get "/projects/:id" do |env|
+          id = env.params.url["id"]
+          env.response.content_type = "application/json"
+
+          # TODO: Proxy to Simple API and transform to ForgeFed Project format
+          env.response.status_code = 404
+          {error: {code: "NOT_FOUND", message: "Project not found: #{id}"}}.to_json
+        end
+
+        get "/projects/:id/tickets" do |env|
+          id = env.params.url["id"]
+          env.response.content_type = "application/json"
+
+          # TODO: Proxy tasks from Simple API for the given project
+          {
+            data: [] of JSON::Any,
+            meta: {
+              projectId:  id,
+              total:      0,
+              page:       1,
+              pageSize:   20,
+              totalPages: 0,
+              timestamp:  Time.utc.to_s,
+            },
+          }.to_json
+        end
+      end
+    end
+  end
+end

--- a/services/crater/src/crater/handlers/tasks.cr
+++ b/services/crater/src/crater/handlers/tasks.cr
@@ -1,0 +1,69 @@
+require "kemal"
+require "json"
+require "http/client"
+require "../utils/config"
+
+module Crater
+  module Handlers
+    module Tasks
+      # Proxy task requests to the Simple API service
+      def self.register(config : Utils::Config)
+        get "/api/tasks" do |env|
+          forward(env, config, "GET", "/api/tasks", query: env.request.query)
+        end
+
+        get "/api/tasks/:id" do |env|
+          id = env.params.url["id"]
+          forward(env, config, "GET", "/api/tasks/#{id}")
+        end
+
+        post "/api/tasks" do |env|
+          body = env.request.body.try(&.gets_to_end) || ""
+          forward(env, config, "POST", "/api/tasks", body: body)
+        end
+
+        put "/api/tasks/:id" do |env|
+          id = env.params.url["id"]
+          body = env.request.body.try(&.gets_to_end) || ""
+          forward(env, config, "PUT", "/api/tasks/#{id}", body: body)
+        end
+
+        delete "/api/tasks/:id" do |env|
+          id = env.params.url["id"]
+          forward(env, config, "DELETE", "/api/tasks/#{id}")
+        end
+      end
+
+      private def self.forward(
+        env : HTTP::Server::Context,
+        config : Utils::Config,
+        method : String,
+        path : String,
+        query : String? = nil,
+        body : String? = nil
+      ) : String
+        uri = URI.parse(config.simple_api_url)
+        full_path = query ? "#{path}?#{query}" : path
+
+        headers = HTTP::Headers{
+          "Content-Type" => "application/json",
+          "Accept"       => "application/json",
+        }
+
+        response = HTTP::Client.exec(
+          method: method,
+          url: "#{config.simple_api_url}#{full_path}",
+          headers: headers,
+          body: body
+        )
+
+        env.response.status_code = response.status_code
+        env.response.content_type = "application/json"
+        response.body
+      rescue ex
+        env.response.status_code = 502
+        {error: {code: "PROXY_ERROR", message: "Failed to reach Simple API: #{ex.message}"}}.to_json
+      end
+    end
+  end
+end

--- a/services/crater/src/crater/handlers/webfinger.cr
+++ b/services/crater/src/crater/handlers/webfinger.cr
@@ -1,0 +1,37 @@
+require "kemal"
+require "json"
+require "../utils/config"
+
+module Crater
+  module Handlers
+    module WebFinger
+      def self.register(config : Utils::Config)
+        get "/.well-known/webfinger" do |env|
+          resource = env.params.query["resource"]?
+
+          unless resource
+            env.response.status_code = 400
+            next({error: "resource parameter required"}.to_json)
+          end
+
+          env.response.content_type = "application/jrd+json"
+
+          {
+            subject:  resource,
+            aliases:  [
+              "http://#{config.domain}/actor",
+              "http://#{config.domain}/u/#{config.actor_username}",
+            ],
+            links: [
+              {
+                rel:  "self",
+                type: "application/activity+json",
+                href: config.actor_id,
+              },
+            ],
+          }.to_json
+        end
+      end
+    end
+  end
+end

--- a/services/crater/src/crater/middleware/cors.cr
+++ b/services/crater/src/crater/middleware/cors.cr
@@ -1,0 +1,20 @@
+require "kemal"
+
+module Crater
+  class CorsHandler
+    include HTTP::Handler
+
+    def call(context : HTTP::Server::Context)
+      context.response.headers["Access-Control-Allow-Origin"] = "*"
+      context.response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS"
+      context.response.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization, Accept"
+
+      if context.request.method == "OPTIONS"
+        context.response.status_code = 204
+        return
+      end
+
+      call_next(context)
+    end
+  end
+end

--- a/services/crater/src/crater/middleware/logger.cr
+++ b/services/crater/src/crater/middleware/logger.cr
@@ -1,0 +1,20 @@
+require "kemal"
+
+module Crater
+  class RequestLogger
+    include HTTP::Handler
+
+    def call(context : HTTP::Server::Context)
+      start = Time.monotonic
+      request_id = Random::Secure.hex(8)
+
+      context.response.headers["X-Request-Id"] = request_id
+      puts "[#{request_id}] #{context.request.method} #{context.request.path}"
+
+      call_next(context)
+
+      duration = (Time.monotonic - start).total_milliseconds.round(2)
+      puts "[#{request_id}] #{context.response.status_code} - #{duration}ms"
+    end
+  end
+end

--- a/services/crater/src/crater/utils/config.cr
+++ b/services/crater/src/crater/utils/config.cr
@@ -1,0 +1,48 @@
+module Crater
+  module Utils
+    struct Config
+      getter port : Int32
+      getter host : String
+      getter env : String
+      getter simple_api_url : String
+      getter domain : String
+      getter actor_username : String
+      getter log_level : String
+
+      def initialize(
+        @port : Int32,
+        @host : String,
+        @env : String,
+        @simple_api_url : String,
+        @domain : String,
+        @actor_username : String,
+        @log_level : String
+      )
+      end
+
+      def self.load(env : Hash(String, String) = ENV.to_h) : Config
+        new(
+          port: env.fetch("PORT", "3001").to_i,
+          host: env.fetch("HOST", "0.0.0.0"),
+          env: env.fetch("CRYSTAL_ENV", "development"),
+          simple_api_url: env.fetch("SIMPLE_API_URL", "http://localhost:4000"),
+          domain: env.fetch("DOMAIN", "localhost:3001"),
+          actor_username: env.fetch("ACTOR_USERNAME", "crater"),
+          log_level: env.fetch("LOG_LEVEL", "info")
+        )
+      end
+
+      def actor_id : String
+        "http://#{domain}/actor"
+      end
+
+      def actor_inbox : String
+        "http://#{domain}/inbox"
+      end
+
+      def actor_outbox : String
+        "http://#{domain}/outbox"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements [OKR-017: Service Architecture (4-Layer Design)](https://github.com/kogeletey/kefine/issues/37), establishing the monorepo structure and scaffolding all four service layers.

### Architecture Overview

```
Kefine Frontend (Svelte)
        │
        ▼ direct connection
Layer 1: services/crater/ (ForgeFed/ActivityPub Proxy — Crystal/Kemal)
        │
        ▼ internal REST API
Layer 2: apps/simple-api/ (Data API — Express/TypeScript)
        │
        ▼ database protocol
Layer 3: Local Store (PostgreSQL/SQLite — future OKR)
        │
        ▲ federation protocol
Layer 4: External Federation Servers (ForgeFed, ActivityPub)
```

### Changes

#### Phase 1: Architecture Setup

**`chore: create project structure`**
- Add monorepo directories: `apps/`, `packages/`, `services/`
- Configure Bun workspaces in root `package.json`

**`feat(types): create shared types package`** — `packages/types/`
- `@kefine/types` — shared TypeScript interfaces used across all services
- Task, Project, User domain types
- ApiResponse, ListResponse, ApiErrorResponse API envelope types

**`feat(config): create configuration package`** — `packages/config/`
- `@kefine/config` — typed environment variable loading
- `loadSimpleApiConfig()` for the Simple API service
- `loadCraterConfig()` for the Crater proxy
- Utility helpers: `requireEnv`, `optionalEnv`, `optionalEnvInt`, `optionalEnvBool`

#### Phase 2: Layer 2 — Simple API Service

**`chore(api): initialize Simple API project`** — `apps/simple-api/`
- Express + TypeScript REST API on port `4000`
- Full CRUD for tasks: `GET/POST /api/tasks`, `GET/PUT/DELETE /api/tasks/:id`
- Health endpoints: `/health`, `/health/ready`, `/health/live`
- Request ID injection and structured logging middleware
- Typed `ApiError` error handling middleware
- In-memory `TaskService` (database layer to be added in subsequent OKR)
- Unit tests with Vitest (`task-service.test.ts` — 10 test cases)
- `.env.example` with documented configuration

#### Phase 3: Layer 1 — Crater Proxy Service

**`feat(crater): initialize Crater proxy service scaffold`** — `services/crater/`
- Crystal service using Kemal framework on port `3001`
- **ActivityPub discovery**: WebFinger (`/.well-known/webfinger`), NodeInfo
- **ActivityPub endpoints**: `/actor`, `/inbox` (POST), `/outbox` (GET)
- **ForgeFed endpoints**: `/projects`, `/projects/:id`, `/projects/:id/tickets`
- **Task proxy**: `/api/tasks/*` forwarding to Simple API via HTTP
- CORS and request logging middleware
- ForgeFed types: `Project`, `Ticket`
- ActivityPub types: `Activity`, `Actor`, `OrderedCollection`
- Config via environment variables with sensible defaults

## Test plan

- [ ] Verify TypeScript compiles cleanly: `bun x tsc --noEmit -p packages/types/tsconfig.json`
- [ ] Verify TypeScript compiles cleanly: `bun x tsc --noEmit -p packages/config/tsconfig.json`
- [ ] Verify TypeScript compiles cleanly: `bun x tsc --noEmit -p apps/simple-api/tsconfig.json`
- [ ] Verify lint passes: `npx oxlint src/ packages/types/src/ packages/config/src/ apps/simple-api/src/`
- [ ] Install Simple API deps and run unit tests: `cd apps/simple-api && bun install && bun test`
- [ ] Start Simple API and verify health endpoint responds: `curl http://localhost:4000/health`
- [ ] Create a task via POST and retrieve it via GET
- [ ] Install Crystal + Shards and compile Crater: `cd services/crater && shards install && crystal build src/crater.cr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes kogeletey/kefine#37