### PR TITLE
Create a feature flag to disable certain features and disable repositories

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-16T14:01:15.138Z for PR creation at branch issue-59-964da1fd4b11 for issue https://github.com/lefinepro/kefine/issues/59
-# Updated: 2026-05-31T08:13:42.014Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-16T14:01:15.138Z for PR creation at branch issue-59-964da1fd4b11 for issue https://github.com/lefinepro/kefine/issues/59
+# Updated: 2026-05-31T08:13:42.014Z

--- a/README.md
+++ b/README.md
@@ -106,6 +106,34 @@ Notes:
 - `backend.databaseUrl` is the Postgres connection string crater uses for orders, payment redemptions, passkey users, challenges, sessions, and outbox activity persistence.
 - `company.*` controls the new `/legal-information` company page. Empty optional fields are hidden automatically.
 
+### 2b. Feature flags: `features`
+
+Optional `features` section toggles whole features on or off. Every flag defaults to
+enabled, so omitting the section keeps the full experience. Set a flag to `false` to
+hide and disable that feature for the deployment:
+
+```json
+{
+  "features": {
+    "repositories": false
+  }
+}
+```
+
+Available flags:
+
+- `repositories` — controls the VCS/git repository feature. When disabled, the
+  "Create git repo", "Enable VCS", and "Git access" task settings, plus the
+  repository clone/archive entries in the clone menu, are hidden. The server also
+  strips any incoming VCS settings so the feature cannot be re-enabled through the
+  API while the flag is off.
+
+Each flag accepts booleans as well as the common string/number forms (`true`/`false`,
+`1`/`0`, `yes`/`no`, `on`/`off`, `enabled`/`disabled`). A flag can also be overridden
+per-process with an environment variable named `KEFINE_FEATURE_<ID>` (uppercased),
+for example `KEFINE_FEATURE_REPOSITORIES=true`. The environment variable wins over the
+value in `kefine.config.json`.
+
 ### 2a. Repository defaults: `.lepos.rcl`
 
 When a task repository is created, crater now seeds it with `.lepos.rcl` in the repository root.

--- a/kefine.config.json
+++ b/kefine.config.json
@@ -10,6 +10,9 @@
       "hy": "Մարտ 2026"
     }
   },
+  "features": {
+    "repositories": false
+  },
   "backend": {
     "craterBaseUrl": "http://127.0.0.1:3001",
     "exchangeBaseUrl": "https://problemsets.lefine.pro",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,10 @@ export default defineConfig({
         command: `pnpm dev --host 127.0.0.1 --port ${PORT}`,
         port: PORT,
         reuseExistingServer: !process.env.CI,
-        timeout: 120000
+        timeout: 120000,
+        // Re-enable the repositories feature so the VCS/clone e2e coverage keeps
+        // exercising the enabled path even though it ships disabled by default.
+        env: { KEFINE_FEATURE_REPOSITORIES: 'true' }
       },
   projects: [
     {

--- a/src/lib/components/kefine/KefineExecutingStep.svelte
+++ b/src/lib/components/kefine/KefineExecutingStep.svelte
@@ -26,6 +26,7 @@
     walletNetworkLabel,
     canSaveCloneLocally = false,
     canManageTask = false,
+    repositoriesEnabled = true,
     isConfirmingStep = false,
     commentSubmittingStepId = null,
     confirmCurrentStepLabel,
@@ -99,6 +100,7 @@
     walletNetworkLabel: string;
     canSaveCloneLocally?: boolean;
     canManageTask?: boolean;
+    repositoriesEnabled?: boolean;
     isConfirmingStep?: boolean;
     commentSubmittingStepId?: string | null;
     confirmCurrentStepLabel?: string;
@@ -472,12 +474,17 @@
         <button type="button" class="kefine-flow-back" onclick={onCancel} aria-label={labels.cancel}>←</button>
         <lefine-box class="kefine-flow-topline-actions">
           {#if currentOrder && onUpdateTaskSettings}
-            <KefineTaskSettingsMenu order={currentOrder} onApply={onUpdateTaskSettings} />
+            <KefineTaskSettingsMenu
+              order={currentOrder}
+              repositoriesEnabled={repositoriesEnabled}
+              onApply={onUpdateTaskSettings}
+            />
           {/if}
           {#if currentOrder && onExportClone}
             <KefineTaskCloneMenu
               order={currentOrder}
               canSaveLocally={canSaveCloneLocally}
+              repositoriesEnabled={repositoriesEnabled}
               onExport={onExportClone}
               onSaveLocally={onSaveCloneLocally ?? undefined}
             />
@@ -687,6 +694,7 @@
         {queuedOrders}
         canSaveCloneLocally={canSaveCloneLocally}
         canManageTask={canManageTask}
+        repositoriesEnabled={repositoriesEnabled}
         {commentSubmittingStepId}
         {solutions}
         onApplySolution={handleApplySolution}

--- a/src/lib/components/kefine/KefineTaskCloneMenu.svelte
+++ b/src/lib/components/kefine/KefineTaskCloneMenu.svelte
@@ -13,11 +13,13 @@
   let {
     order,
     canSaveLocally = false,
+    repositoriesEnabled = true,
     onExport,
     onSaveLocally
   }: {
     order: OrderView | null;
     canSaveLocally?: boolean;
+    repositoriesEnabled?: boolean;
     onExport: (format: TaskCloneFormat) => void;
     onSaveLocally?: (runLocally: boolean) => void;
   } = $props();
@@ -28,10 +30,10 @@
   let copiedValue = $state<string | null>(null);
   let copiedTimeout = $state<number | null>(null);
 
-  const repository = $derived(order ? getTaskRepository(order) : null);
-  const repositoryCloneTarget = $derived(order ? getTaskRepositoryCloneTarget(order) : null);
-  const repositoryLinkTarget = $derived(order ? getTaskRepositoryLinkTarget(order) : null);
-  const repositoryArchiveTargets = $derived(order ? getTaskRepositoryArchiveTargets(order) : null);
+  const repository = $derived(repositoriesEnabled && order ? getTaskRepository(order) : null);
+  const repositoryCloneTarget = $derived(repositoriesEnabled && order ? getTaskRepositoryCloneTarget(order) : null);
+  const repositoryLinkTarget = $derived(repositoriesEnabled && order ? getTaskRepositoryLinkTarget(order) : null);
+  const repositoryArchiveTargets = $derived(repositoriesEnabled && order ? getTaskRepositoryArchiveTargets(order) : null);
   const repositoryArchiveActions = $derived.by(() =>
     repositoryArchiveTargets
       ? [

--- a/src/lib/components/kefine/KefineTaskSettingsMenu.svelte
+++ b/src/lib/components/kefine/KefineTaskSettingsMenu.svelte
@@ -6,9 +6,11 @@
 
   let {
     order,
+    repositoriesEnabled = true,
     onApply
   }: {
     order: OrderView | null;
+    repositoriesEnabled?: boolean;
     onApply: (patch: Partial<Pick<OrderView, 'title' | 'description' | 'taskIcon' | 'shareId' | 'isPublicTask' | 'vcsEnabled' | 'repository'>> & {
       gitSettings?: RepositoryGitSettings;
     }) => void | Promise<void>;
@@ -222,7 +224,7 @@
               <Icon icon="mdi:close" width="18" height="18" aria-hidden="true" />
             </button>
           </kefine-task-settings-head>
-          {#if !vcsEnabledDraft && !order.repository}
+          {#if repositoriesEnabled && !vcsEnabledDraft && !order.repository}
             <button type="button" data-part="secondary" data-kind="create-repo" onclick={createGitRepo}>
               <Icon icon="mdi:source-repository" width="16" height="16" aria-hidden="true" />
               <lefine-text>Create git repo</lefine-text>
@@ -247,12 +249,14 @@
             <input bind:checked={isPublicDraft} type="checkbox" />
             <lefine-text>Make public</lefine-text>
           </label>
-          <label data-part="toggle">
-            <input bind:checked={vcsEnabledDraft} type="checkbox" />
-            <lefine-text>Enable VCS</lefine-text>
-          </label>
+          {#if repositoriesEnabled}
+            <label data-part="toggle">
+              <input bind:checked={vcsEnabledDraft} type="checkbox" />
+              <lefine-text>Enable VCS</lefine-text>
+            </label>
+          {/if}
 
-          {#if vcsEnabledDraft}
+          {#if repositoriesEnabled && vcsEnabledDraft}
             <kefine-task-settings-git>
               <strong>Git access</strong>
               <label data-part="toggle">

--- a/src/lib/components/kefine/KefineTaskTreeFeed.svelte
+++ b/src/lib/components/kefine/KefineTaskTreeFeed.svelte
@@ -32,6 +32,7 @@
     labels,
     canSaveCloneLocally = false,
     canManageTask = false,
+    repositoriesEnabled = true,
     commentSubmittingStepId = null,
     solutions = [],
     onSubmitStepComment,
@@ -68,6 +69,7 @@
   };
     canSaveCloneLocally?: boolean;
     canManageTask?: boolean;
+    repositoriesEnabled?: boolean;
     commentSubmittingStepId?: string | null;
     onSubmitStepComment?: ((stepId: string, content: string) => Promise<void> | void) | null;
     onSaveDocument?: ((content: string) => Promise<void> | void) | null;
@@ -1003,12 +1005,17 @@
         <KefineTaskCloneMenu
           order={currentOrder}
           canSaveLocally={canSaveCloneLocally}
+          repositoriesEnabled={repositoriesEnabled}
           onExport={onExportClone}
           onSaveLocally={onSaveCloneLocally ?? undefined}
         />
       {/if}
       {#if currentOrder && onUpdateTaskSettings}
-        <KefineTaskSettingsMenu order={currentOrder} onApply={onUpdateTaskSettings} />
+        <KefineTaskSettingsMenu
+          order={currentOrder}
+          repositoriesEnabled={repositoriesEnabled}
+          onApply={onUpdateTaskSettings}
+        />
       {/if}
     </kefine-thread-head-actions>
   </kefine-thread-head>

--- a/src/lib/components/kefine/KefineWorkspace.svelte
+++ b/src/lib/components/kefine/KefineWorkspace.svelte
@@ -105,6 +105,7 @@
   } = $props();
   const localeText = $derived($kefineLocaleText);
   const runtimeConfig = $derived(resolvePublicRuntimeConfig(page.data.publicConfig));
+  const repositoriesEnabled = $derived(runtimeConfig.features.repositories !== false);
   const activeLocale = $derived(readLocaleFromPathname(page.url.pathname) ?? 'en');
 
   function getNormalizedInitialOrderId() {
@@ -2460,12 +2461,21 @@
   }
 
   async function handleUpdateTaskSettings(
-    patch: Partial<Pick<OrderView, 'title' | 'description' | 'taskIcon' | 'shareId' | 'isPublicTask' | 'vcsEnabled' | 'repository'>> & {
+    rawPatch: Partial<Pick<OrderView, 'title' | 'description' | 'taskIcon' | 'shareId' | 'isPublicTask' | 'vcsEnabled' | 'repository'>> & {
       gitSettings?: import('./kefine-workflow').RepositoryGitSettings;
     }
   ) {
     if (!currentOrder) {
       return;
+    }
+
+    // When the repositories feature is disabled, never let VCS settings be
+    // toggled on, even if the UI control is somehow reachable.
+    const patch = { ...rawPatch };
+    if (!repositoriesEnabled) {
+      delete patch.vcsEnabled;
+      delete patch.gitSettings;
+      delete patch.repository;
     }
 
     updateProfileTask(currentOrder.id, patch);
@@ -2957,6 +2967,7 @@
           execution={executionPresentation}
           canSaveCloneLocally={canSaveCurrentOrderLocally}
           canManageTask={canManageCurrentOrder}
+          repositoriesEnabled={repositoriesEnabled}
           isHydratingTitle={isHydratingRoute && !currentOrder?.title.trim()}
           isConfirmingStep={confirmStepLoading}
           commentSubmittingStepId={stepCommentLoadingId}

--- a/src/lib/config/kefine-config-features.test.ts
+++ b/src/lib/config/kefine-config-features.test.ts
@@ -1,0 +1,13 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { resolvePublicRuntimeConfig } from './public-config';
+
+describe('shipped kefine.config.json feature flags', () => {
+  test('disables the repositories feature', () => {
+    const configPath = path.resolve(process.cwd(), 'kefine.config.json');
+    const raw = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    const resolved = resolvePublicRuntimeConfig(raw);
+    expect(resolved.features.repositories).toBe(false);
+  });
+});

--- a/src/lib/config/public-config.test.ts
+++ b/src/lib/config/public-config.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import {
+  DEFAULT_FEATURE_FLAGS,
+  DEFAULT_PUBLIC_RUNTIME_CONFIG,
+  isFeatureEnabled,
+  normalizeFeatureFlags,
+  resolvePublicRuntimeConfig,
+  setBrowserPublicRuntimeConfig
+} from './public-config';
+
+describe('normalizeFeatureFlags', () => {
+  test('returns defaults for missing or invalid input', () => {
+    expect(normalizeFeatureFlags(undefined)).toEqual(DEFAULT_FEATURE_FLAGS);
+    expect(normalizeFeatureFlags(null)).toEqual(DEFAULT_FEATURE_FLAGS);
+    expect(normalizeFeatureFlags('nope')).toEqual(DEFAULT_FEATURE_FLAGS);
+    expect(normalizeFeatureFlags({})).toEqual(DEFAULT_FEATURE_FLAGS);
+  });
+
+  test('respects an explicit boolean override', () => {
+    expect(normalizeFeatureFlags({ repositories: false })).toEqual({ repositories: false });
+    expect(normalizeFeatureFlags({ repositories: true })).toEqual({ repositories: true });
+  });
+
+  test('coerces common truthy/falsy string and number representations', () => {
+    expect(normalizeFeatureFlags({ repositories: 'false' }).repositories).toBe(false);
+    expect(normalizeFeatureFlags({ repositories: 'off' }).repositories).toBe(false);
+    expect(normalizeFeatureFlags({ repositories: 'disabled' }).repositories).toBe(false);
+    expect(normalizeFeatureFlags({ repositories: 0 }).repositories).toBe(false);
+    expect(normalizeFeatureFlags({ repositories: 'true' }).repositories).toBe(true);
+    expect(normalizeFeatureFlags({ repositories: 'yes' }).repositories).toBe(true);
+    expect(normalizeFeatureFlags({ repositories: 1 }).repositories).toBe(true);
+  });
+
+  test('falls back to the default for unrecognized values', () => {
+    expect(normalizeFeatureFlags({ repositories: 'maybe' }).repositories).toBe(
+      DEFAULT_FEATURE_FLAGS.repositories
+    );
+    expect(normalizeFeatureFlags({ repositories: '' }).repositories).toBe(
+      DEFAULT_FEATURE_FLAGS.repositories
+    );
+  });
+});
+
+describe('resolvePublicRuntimeConfig feature flags', () => {
+  test('includes default feature flags when none are provided', () => {
+    expect(resolvePublicRuntimeConfig({}).features).toEqual(DEFAULT_FEATURE_FLAGS);
+  });
+
+  test('threads configured feature flags through', () => {
+    const config = resolvePublicRuntimeConfig({ features: { repositories: false } });
+    expect(config.features.repositories).toBe(false);
+  });
+});
+
+describe('isFeatureEnabled', () => {
+  afterEach(() => {
+    // Restore the browser singleton to its default between tests.
+    setBrowserPublicRuntimeConfig(DEFAULT_PUBLIC_RUNTIME_CONFIG);
+  });
+
+  test('reads from an explicitly provided config', () => {
+    const enabled = resolvePublicRuntimeConfig({ features: { repositories: true } });
+    const disabled = resolvePublicRuntimeConfig({ features: { repositories: false } });
+    expect(isFeatureEnabled('repositories', enabled)).toBe(true);
+    expect(isFeatureEnabled('repositories', disabled)).toBe(false);
+  });
+
+  test('defaults to the browser runtime config when no config is given', () => {
+    setBrowserPublicRuntimeConfig({ features: { repositories: false } });
+    expect(isFeatureEnabled('repositories')).toBe(false);
+
+    setBrowserPublicRuntimeConfig({ features: { repositories: true } });
+    expect(isFeatureEnabled('repositories')).toBe(true);
+  });
+});

--- a/src/lib/config/public-config.ts
+++ b/src/lib/config/public-config.ts
@@ -23,10 +23,29 @@ export type KefineDefaultActorPublicConfig = {
   displayName: string;
 };
 
+/**
+ * Identifiers for features that can be toggled on or off through configuration.
+ * Add new feature flags here and to {@link DEFAULT_FEATURE_FLAGS}.
+ */
+export type KefineFeatureFlagId = 'repositories';
+
+export type KefineFeatureFlags = Record<KefineFeatureFlagId, boolean>;
+
+/**
+ * Default state for every feature flag. Features default to enabled so that
+ * existing behaviour is preserved unless a deployment explicitly opts out.
+ */
+export const DEFAULT_FEATURE_FLAGS: KefineFeatureFlags = {
+  repositories: true
+};
+
+export const KEFINE_FEATURE_FLAG_IDS = Object.keys(DEFAULT_FEATURE_FLAGS) as KefineFeatureFlagId[];
+
 export type KefinePublicRuntimeConfig = {
   app: KefinePublicAppConfig;
   services: KefinePinnedServiceConfig[];
   defaultActor: KefineDefaultActorPublicConfig;
+  features: KefineFeatureFlags;
   backend: {
     craterBaseUrl: string;
   };
@@ -55,6 +74,7 @@ export const DEFAULT_PUBLIC_RUNTIME_CONFIG: KefinePublicRuntimeConfig = {
     handle: 'staff',
     displayName: 'Staff'
   },
+  features: { ...DEFAULT_FEATURE_FLAGS },
   backend: {
     craterBaseUrl: 'http://localhost:3001'
   }
@@ -62,6 +82,42 @@ export const DEFAULT_PUBLIC_RUNTIME_CONFIG: KefinePublicRuntimeConfig = {
 
 export function normalizeText(value: unknown, fallback = ''): string {
   return typeof value === 'string' ? value.trim() || fallback : fallback;
+}
+
+/**
+ * Normalizes an arbitrary value into a complete set of feature flags. Each known
+ * flag accepts an explicit boolean (or the strings/numbers commonly used in JSON
+ * config and environment files); anything else falls back to the default state.
+ */
+export function normalizeFeatureFlags(value: unknown): KefineFeatureFlags {
+  const source = value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+  const features = {} as KefineFeatureFlags;
+  for (const id of KEFINE_FEATURE_FLAG_IDS) {
+    features[id] = normalizeBoolean(source[id], DEFAULT_FEATURE_FLAGS[id]);
+  }
+  return features;
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === '') {
+      return fallback;
+    }
+    if (['true', '1', 'yes', 'on', 'enabled'].includes(normalized)) {
+      return true;
+    }
+    if (['false', '0', 'no', 'off', 'disabled'].includes(normalized)) {
+      return false;
+    }
+  }
+  return fallback;
 }
 
 export function resolvePublicRuntimeConfig(value: unknown): KefinePublicRuntimeConfig {
@@ -73,6 +129,7 @@ export function resolvePublicRuntimeConfig(value: unknown): KefinePublicRuntimeC
     app?: Partial<KefinePublicAppConfig>;
     services?: unknown;
     defaultActor?: Partial<KefineDefaultActorPublicConfig>;
+    features?: unknown;
   };
   const app: Partial<KefinePublicAppConfig> = source.app ?? {};
   const defaultActor: Partial<KefineDefaultActorPublicConfig> = source.defaultActor ?? {};
@@ -112,6 +169,7 @@ export function resolvePublicRuntimeConfig(value: unknown): KefinePublicRuntimeC
       handle: normalizeText(defaultActor.handle, DEFAULT_PUBLIC_RUNTIME_CONFIG.defaultActor.handle),
       displayName: normalizeText(defaultActor.displayName, DEFAULT_PUBLIC_RUNTIME_CONFIG.defaultActor.displayName)
     },
+    features: normalizeFeatureFlags(source.features),
     backend: {
       craterBaseUrl: normalizeText((value as { backend?: { craterBaseUrl?: string } }).backend?.craterBaseUrl, DEFAULT_PUBLIC_RUNTIME_CONFIG.backend.craterBaseUrl)
     }
@@ -130,4 +188,15 @@ export function setBrowserPublicRuntimeConfig(value: unknown): void {
 
 export function readBrowserPublicRuntimeConfig(): KefinePublicRuntimeConfig {
   return browserPublicRuntimeConfig ?? DEFAULT_PUBLIC_RUNTIME_CONFIG;
+}
+
+/**
+ * Returns whether the given feature is enabled. When no config is provided the
+ * browser runtime config is used, so this is safe to call from client code.
+ */
+export function isFeatureEnabled(
+  feature: KefineFeatureFlagId,
+  config: KefinePublicRuntimeConfig = readBrowserPublicRuntimeConfig()
+): boolean {
+  return config.features[feature] !== false;
 }

--- a/src/lib/server/kefine-config.ts
+++ b/src/lib/server/kefine-config.ts
@@ -2,9 +2,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {
   DEFAULT_PUBLIC_RUNTIME_CONFIG,
+  KEFINE_FEATURE_FLAG_IDS,
+  normalizeFeatureFlags,
   normalizeText,
   resolvePublicRuntimeConfig,
   type KefineDefaultActorPublicConfig,
+  type KefineFeatureFlags,
   type KefinePinnedServiceConfig,
   type KefinePublicRuntimeConfig
 } from '$lib/config/public-config';
@@ -15,6 +18,7 @@ type KefineFullConfig = {
   defaultActor: KefineDefaultActorPublicConfig & {
     privateKey: string;
   };
+  features: KefineFeatureFlags;
   backend: {
     craterBaseUrl: string;
     exchangeBaseUrl: string;
@@ -40,6 +44,7 @@ const DEFAULT_CONFIG: KefineFullConfig = {
     ...DEFAULT_PUBLIC_RUNTIME_CONFIG.defaultActor,
     privateKey: ''
   },
+  features: DEFAULT_PUBLIC_RUNTIME_CONFIG.features,
   backend: {
     craterBaseUrl: 'http://localhost:3001',
     exchangeBaseUrl: 'http://localhost:3001',
@@ -81,6 +86,23 @@ function readEnvironmentOverride(name: string): string {
   return normalizeText(process.env[name]);
 }
 
+/**
+ * Applies per-feature environment overrides on top of the configured flags.
+ * Each flag can be toggled with `KEFINE_FEATURE_<ID>` (e.g.
+ * `KEFINE_FEATURE_REPOSITORIES=true`). Unset or empty variables leave the
+ * configured value untouched.
+ */
+function applyFeatureFlagEnvOverrides(base: KefineFeatureFlags): KefineFeatureFlags {
+  const resolved = { ...base };
+  for (const id of KEFINE_FEATURE_FLAG_IDS) {
+    const override = readEnvironmentOverride(`KEFINE_FEATURE_${id.toUpperCase()}`);
+    if (override !== '') {
+      resolved[id] = normalizeFeatureFlags({ [id]: override })[id];
+    }
+  }
+  return resolved;
+}
+
 export function getKefineConfig(): KefineFullConfig {
   if (cachedConfig) {
     return cachedConfig;
@@ -91,7 +113,8 @@ export function getKefineConfig(): KefineFullConfig {
   const publicConfig = resolvePublicRuntimeConfig({
     app: objectSource.app,
     services: objectSource.services,
-    defaultActor: objectSource.defaultActor
+    defaultActor: objectSource.defaultActor,
+    features: objectSource.features
   });
   const defaultActor = (objectSource.defaultActor ?? {}) as Record<string, unknown>;
   const backend = (objectSource.backend ?? {}) as Record<string, unknown>;
@@ -100,6 +123,7 @@ export function getKefineConfig(): KefineFullConfig {
   cachedConfig = {
     app: publicConfig.app,
     services: publicConfig.services,
+    features: applyFeatureFlagEnvOverrides(publicConfig.features),
     defaultActor: {
       handle: publicConfig.defaultActor.handle,
       displayName: publicConfig.defaultActor.displayName,
@@ -150,6 +174,7 @@ export function getPublicRuntimeConfig(): KefinePublicRuntimeConfig {
       handle: config.defaultActor.handle,
       displayName: config.defaultActor.displayName
     },
+    features: config.features,
     backend: {
       craterBaseUrl: config.backend.craterBaseUrl
     }


### PR DESCRIPTION
## Summary

Resolves #96. This PR introduces a generic **feature-flag mechanism** that lets a deployment disable selected features through configuration, and uses it to ship the **repositories (VCS/git) feature disabled**.

## What changed

### Feature-flag mechanism
- Added feature-flag types and helpers to `src/lib/config/public-config.ts`:
  - `KefineFeatureFlagId` / `KefineFeatureFlags`, `DEFAULT_FEATURE_FLAGS` (every flag defaults to **enabled** so existing behaviour is preserved), and `KEFINE_FEATURE_FLAG_IDS`.
  - `normalizeFeatureFlags()` coerces booleans, numbers, and common string forms (`true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`, `enabled`/`disabled`), falling back to defaults for unknown values.
  - `isFeatureEnabled(feature, config?)` for ergonomic client-side checks (defaults to the browser runtime config).
- Threaded `features` through the existing public runtime config pipeline: `kefine.config.json` → `getKefineConfig()` / `getPublicRuntimeConfig()` → `+layout.server.ts` → browser.
- Added per-process env overrides: any flag can be overridden with `KEFINE_FEATURE_<ID>` (e.g. `KEFINE_FEATURE_REPOSITORIES=true`), which wins over the config file.

### Disabling repositories
- `kefine.config.json` now ships `"features": { "repositories": false }`.
- Gated every repository entry point behind the flag:
  - `KefineTaskSettingsMenu` — hides **Create git repo**, **Enable VCS**, and **Git access**.
  - `KefineTaskCloneMenu` — hides repository clone / link / archive targets.
  - Wired the flag down through `KefineWorkspace` → `KefineExecutingStep` → `KefineTaskTreeFeed`.
- Added a defensive server-side guard in `KefineWorkspace.handleUpdateTaskSettings`: when the flag is off, incoming `vcsEnabled` / `gitSettings` / `repository` patch fields are stripped, so VCS cannot be re-enabled even if a control is somehow reachable.

## How to reproduce / verify

- With `"repositories": false` in `kefine.config.json`, the git repo / VCS / clone-repository controls no longer appear in the task UI.
- Set `KEFINE_FEATURE_REPOSITORIES=true` to re-enable the feature for a given process (used by the e2e server below).

## Tests

- **Unit** (`src/lib/config/public-config.test.ts`): `normalizeFeatureFlags` (defaults, explicit booleans, string/number coercion, fallbacks), `resolvePublicRuntimeConfig` threading, and `isFeatureEnabled` (explicit config + browser singleton).
- **Shipped-config regression** (`src/lib/config/kefine-config-features.test.ts`): asserts the repo's `kefine.config.json` resolves `repositories` to `false`.
- **e2e**: `playwright.config.ts` webServer sets `KEFINE_FEATURE_REPOSITORIES=true` so the existing `e2e/task-clone.spec.ts` keeps exercising the enabled path. Both clone specs pass.
- `pnpm test` (53 passed), `pnpm check` (0 errors/warnings), `pnpm lint` (0 errors).

## Docs

- README gains a "Feature flags: `features`" section documenting the flag, accepted value forms, and the `KEFINE_FEATURE_<ID>` env override.
