### PR TITLE
feat: add repository feature flag

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-31T09:58:28.117Z for PR creation at branch issue-99-0ec3ed5eb144 for issue https://github.com/lefinepro/kefine/issues/99

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-31T09:58:28.117Z for PR creation at branch issue-99-0ec3ed5eb144 for issue https://github.com/lefinepro/kefine/issues/99

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Main sections:
   "app": {
     "reownProjectId": "your_reown_project_id"
   },
+  "features": {
+    "repositories": false
+  },
   "origins": {
     "primary": "https://lefine.pro",
     "legal": "https://legal.lefine.pro",
@@ -104,9 +107,36 @@ Notes:
 - `backend.craterBaseUrl` is the crater base URL used by the SvelteKit proxy for order, payment, and passkey operations.
 - `backend.exchangeBaseUrl` is the exchange base URL crater uses for user IDs and payment links.
 - `backend.databaseUrl` is the Postgres connection string crater uses for orders, payment redemptions, passkey users, challenges, sessions, and outbox activity persistence.
+- `features.repositories` controls the VCS/git repository feature.
 - `company.*` controls the new `/legal-information` company page. Empty optional fields are hidden automatically.
 
-### 2a. Repository defaults: `.lepos.rcl`
+### 2a. Feature flags: `features`
+
+Optional `features` section toggles whole features on or off. Every flag defaults to
+enabled, so omitting the section keeps the full experience. Set a flag to `false` to
+hide and disable that feature for the deployment:
+
+```json
+{
+  "features": {
+    "repositories": false
+  }
+}
+```
+
+Available flags:
+
+- `repositories` - controls the VCS/git repository feature. When disabled, the
+  "Create git repo", "Enable VCS", "Git access", repository clone/archive entries,
+  Crater project/git/ForgeFed/SSH-key routes, and API-side VCS creation are disabled.
+
+Each flag accepts booleans as well as common string/number forms (`true`/`false`,
+`1`/`0`, `yes`/`no`, `on`/`off`, `enabled`/`disabled`). A flag can also be overridden
+per process with an environment variable named `KEFINE_FEATURE_<ID>` (uppercased),
+for example `KEFINE_FEATURE_REPOSITORIES=true`. The environment variable wins over the
+value in `kefine.config.json`.
+
+### 2b. Repository defaults: `.lepos.rcl`
 
 When a task repository is created, crater now seeds it with `.lepos.rcl` in the repository root.
 You can use this config to control repository storage behavior:

--- a/crater/src/crater.cr
+++ b/crater/src/crater.cr
@@ -72,10 +72,14 @@ module Crater
     Handlers::EmailCodeAuth.register(config)
 
     # ForgeFed project endpoints
-    Handlers::Projects.register(config)
-    Handlers::GitHttp.register(config)
-    Handlers::ForgeFedResources.register(config)
-    Handlers::SshKeys.register(config)
+    if config.repositories_enabled
+      Handlers::Projects.register(config)
+      Handlers::GitHttp.register(config)
+      Handlers::ForgeFedResources.register(config)
+      Handlers::SshKeys.register(config)
+    else
+      puts "[crater] repositories feature disabled"
+    end
 
     get "/health" do |env|
       env.response.content_type = "application/json"
@@ -93,10 +97,18 @@ config = Crater::Utils::Config.load
 
 case ARGV.first?
 when "authorized-keys"
-  Crater::SshKeyStore.print_authorized_keys(STDOUT, config)
+  Crater::SshKeyStore.print_authorized_keys(STDOUT, config) if config.repositories_enabled
 when "ssh-shell"
+  unless config.repositories_enabled
+    STDERR.puts "Repositories feature is disabled."
+    exit(1)
+  end
   Crater::SshGitShell.run(config, ARGV[1..])
 when "git-receive-hook"
+  unless config.repositories_enabled
+    STDERR.puts "Repositories feature is disabled."
+    exit(1)
+  end
   Crater::GitReceiveHook.run(config, ARGV[1..])
 else
   Crater.run

--- a/crater/src/crater/git_receive_hook.cr
+++ b/crater/src/crater/git_receive_hook.cr
@@ -133,6 +133,8 @@ module Crater
     end
 
     def self.run(config : Utils::Config, args : Array(String)) : NoReturn
+      deny("Repositories feature is disabled.") unless config.repositories_enabled
+
       stage = parse_stage(args)
       repository_id = parse_arg(args, "--repo-id")
       repository = RepositoryStore.find_by_id(repository_id, config)

--- a/crater/src/crater/handlers/orders.cr
+++ b/crater/src/crater/handlers/orders.cr
@@ -69,7 +69,8 @@ module Crater
           "solver=#{record.solver_name || record.solver} actorHandle=#{record.actor_handle || "-"}"
         end
 
-        repository = if record.vcs_enabled
+        vcs_enabled = config.repositories_enabled && record.vcs_enabled
+        repository = if vcs_enabled
                        begin
                          RepositoryStore.ensure_for_order(record, config)
                        rescue ex
@@ -92,7 +93,7 @@ module Crater
           ownerDisplayName: record.owner_display_name,
           actorHandle: record.actor_handle,
           actorDid: record.actor_did,
-          vcsEnabled: record.vcs_enabled,
+          vcsEnabled: vcs_enabled,
           uiScenario: record.ui_scenario,
           projectId: repository.try(&.project_id),
           repository: repository ? RepositoryStore.to_json_payload(repository) : nil

--- a/crater/src/crater/handlers/status.cr
+++ b/crater/src/crater/handlers/status.cr
@@ -116,8 +116,8 @@ module Crater
           JSON.parse(%({"format":"markdown","content":""}))
         end
         activities = OrderQueue.activities_for_order(record.id, config)
-        existing_repository = RepositoryStore.find_by_order(record.id, config)
-        vcs_enabled = record.vcs_enabled || !existing_repository.nil?
+        existing_repository = config.repositories_enabled ? RepositoryStore.find_by_order(record.id, config) : nil
+        vcs_enabled = config.repositories_enabled && (record.vcs_enabled || !existing_repository.nil?)
         repository = if vcs_enabled
                        begin
                          existing_repository || RepositoryStore.ensure_for_order(record, config)
@@ -184,13 +184,15 @@ module Crater
           return({error: "Order not found", orderId: order_id}.to_json)
         end
 
-        begin
-          repository = RepositoryStore.find_by_order(record.id, config) || RepositoryStore.ensure_for_order(record, config)
-          content = JSON.parse(record.document_json || %({"format":"markdown","content":""})).as_h?.try(&.["content"]?).try(&.as_s?) || ""
-          actor = record.actor_handle || record.owner_username || config.actor_username
-          RepositoryStore.commit_plan_document(repository, actor, content, config) unless content.empty?
-        rescue ex
-          Log.error(exception: ex) { "[status] failed to persist PLAN.org for orderId=#{record.id}" }
+        if config.repositories_enabled
+          begin
+            repository = RepositoryStore.find_by_order(record.id, config) || RepositoryStore.ensure_for_order(record, config)
+            content = JSON.parse(record.document_json || %({"format":"markdown","content":""})).as_h?.try(&.["content"]?).try(&.as_s?) || ""
+            actor = record.actor_handle || record.owner_username || config.actor_username
+            RepositoryStore.commit_plan_document(repository, actor, content, config) unless content.empty?
+          rescue ex
+            Log.error(exception: ex) { "[status] failed to persist PLAN.org for orderId=#{record.id}" }
+          end
         end
 
         render_status(env, record.id, config)
@@ -205,17 +207,24 @@ module Crater
           return({error: "Invalid request body", reason: ex.message}.to_json)
         end
 
-        vcs_enabled = payload.as_h?.try(&.["vcsEnabled"]?).try(&.as_bool?)
+        requested_vcs_enabled = payload.as_h?.try(&.["vcsEnabled"]?).try(&.as_bool?)
+        vcs_enabled = if config.repositories_enabled
+                        requested_vcs_enabled
+                      elsif requested_vcs_enabled.nil?
+                        nil
+                      else
+                        false
+                      end
         is_public_task = payload.as_h?.try(&.["isPublicTask"]?).try(&.as_bool?)
-        git_settings_payload = payload.as_h?.try(&.["gitSettings"]?)
+        git_settings_payload = config.repositories_enabled ? payload.as_h?.try(&.["gitSettings"]?) : nil
         record = OrderQueue.update_settings(order_id, vcs_enabled, is_public_task, config)
         if record.nil?
           env.response.status_code = 404
           return({error: "Order not found", orderId: order_id}.to_json)
         end
 
-        repository = RepositoryStore.find_by_order(record.id, config)
-        if record.vcs_enabled
+        repository = config.repositories_enabled ? RepositoryStore.find_by_order(record.id, config) : nil
+        if config.repositories_enabled && record.vcs_enabled
           begin
             repository = RepositoryStore.ensure_for_order(record, config)
           rescue ex

--- a/crater/src/crater/order_queue.cr
+++ b/crater/src/crater/order_queue.cr
@@ -574,7 +574,7 @@ module Crater
       if !record.is_public_task && existing.is_public_task
         record.is_public_task = true
       end
-      if !record.vcs_enabled && existing.vcs_enabled
+      if config.repositories_enabled && !record.vcs_enabled && existing.vcs_enabled
         record.vcs_enabled = true
       end
       if record.labels.empty? && !existing.labels.empty?
@@ -701,7 +701,7 @@ module Crater
       is_vpn_order = vpn_service_payload?(title, description, ui_scenario, labels)
       labels = ensure_vpn_label(labels) if is_vpn_order
       is_public_task = to_bool(payload["isPublicTask"]?) || to_bool(source["isPublicTask"]?) || false
-      vcs_enabled = to_bool(payload["vcsEnabled"]?) || to_bool(source["vcsEnabled"]?) || false
+      vcs_enabled = config.repositories_enabled && (to_bool(payload["vcsEnabled"]?) || to_bool(source["vcsEnabled"]?) || false)
 
       explicit_solver_name = to_string(payload["solverName"]?) || to_string(source["solverName"]?) || to_string(payload["solver"]?) || to_string(source["solver"]?)
       explicit_solver_handle = to_string(payload["solverHandle"]?) || to_string(source["solverHandle"]?) || to_string(payload["performerHandle"]?) || to_string(source["performerHandle"]?)
@@ -788,6 +788,7 @@ module Crater
       attachments = combined_attachments(order, status, config)
       system_instruction = exchange_system_instruction(order)
       routed_comments = routed_comment_payloads(order)
+      vcs_enabled = config.repositories_enabled && order.vcs_enabled
       ticket_payload = {
         "@context" => [ActivityPub::CONTEXT, ForgeFed::CONTEXT],
         "id" => "#{object_id}/ticket",
@@ -814,7 +815,7 @@ module Crater
         "actorHandle" => order.actor_handle,
         "actorDid" => actor_did,
         "isPublicTask" => order.is_public_task,
-        "vcsEnabled" => order.vcs_enabled,
+        "vcsEnabled" => vcs_enabled,
         "document" => JSON.parse(order.document_json || build_default_document_json(order.title, order.description)),
         "attachment" => attachments
       }
@@ -854,7 +855,7 @@ module Crater
         "actorHandle" => order.actor_handle,
         "actorDid" => actor_did,
         "isPublicTask" => order.is_public_task,
-        "vcsEnabled" => order.vcs_enabled,
+        "vcsEnabled" => vcs_enabled,
         "document" => JSON.parse(order.document_json || build_default_document_json(order.title, order.description)),
         "attachment" => attachments
       }

--- a/crater/src/crater/repository_store.cr
+++ b/crater/src/crater/repository_store.cr
@@ -165,6 +165,10 @@ module Crater
       end
     end
 
+    private def self.ensure_enabled!(config : Utils::Config) : Nil
+      raise "Repositories feature is disabled." unless config.repositories_enabled
+    end
+
     private def self.repo_root : String
       presence(ENV["KEFINE_GIT_ROOT"]?.try(&.strip)) || File.expand_path(".meta/crater/git", Dir.current)
     end
@@ -831,6 +835,7 @@ module Crater
       content : String,
       config : Utils::Config = Utils::Config.load
     ) : Nil
+      ensure_enabled!(config)
       temp_path = File.join(worktrees_root, "plan-#{record.id}-#{UUID.random}")
       FileUtils.rm_rf(temp_path)
       FileUtils.mkdir_p(temp_path)
@@ -985,6 +990,7 @@ module Crater
     end
 
     def self.update_git_settings(record : RepositoryRecord, settings : GitSettings, config : Utils::Config = Utils::Config.load) : GitSettings
+      ensure_enabled!(config)
       setup(config)
       normalized = normalize_git_settings(settings, config)
       now = current_time
@@ -1033,6 +1039,7 @@ module Crater
     end
 
     def self.prepare_git_transport(record : RepositoryRecord) : Nil
+      ensure_enabled!(Utils::Config.load)
       install_receive_hooks(record)
     end
 
@@ -1051,6 +1058,7 @@ module Crater
     end
 
     def self.ensure_ad_hoc_for_owner_and_clone_name(owner_handle : String, clone_name : String, config : Utils::Config = Utils::Config.load) : RepositoryRecord
+      ensure_enabled!(config)
       normalized_owner = normalize_handle(owner_handle)
       normalized_clone_name = normalize_clone_name(clone_name)
       existing = find_by_owner_and_project_clone_name(normalized_owner, normalized_clone_name, config)
@@ -1099,6 +1107,7 @@ module Crater
     end
 
     def self.ensure_for_order(order : OrderQueue::OrderRecord, config : Utils::Config = Utils::Config.load) : RepositoryRecord
+      ensure_enabled!(config)
       existing = find_by_order(order.id, config)
       if existing
         visibility = resolve_visibility(order)
@@ -1158,6 +1167,7 @@ module Crater
       config : Utils::Config = Utils::Config.load,
       lepos_settings : LeposConfig::RepositorySettings = LeposConfig::RepositorySettings.default
     ) : String
+      ensure_enabled!(config)
       setup(config)
       return "" unless pull_push_allowed?(branch_name, lepos_settings)
       now = current_time

--- a/crater/src/crater/ssh_git_shell.cr
+++ b/crater/src/crater/ssh_git_shell.cr
@@ -81,6 +81,8 @@ module Crater
     end
 
     def self.run(config : Utils::Config, args : Array(String)) : NoReturn
+      deny("Repositories feature is disabled.") unless config.repositories_enabled
+
       actor_handle = parse_actor(args)
       key = SshKeyStore.find_by_actor(actor_handle, config)
       deny("SSH key is not registered for @#{actor_handle}.") unless key

--- a/crater/src/crater/utils/config.cr
+++ b/crater/src/crater/utils/config.cr
@@ -32,6 +32,7 @@ module Crater
       getter maddy_smtp_password : String?
       getter maddy_from_email : String?
       getter maddy_from_name : String?
+      getter repositories_enabled : Bool
 
       def initialize(
         @port : Int32,
@@ -61,12 +62,14 @@ module Crater
         @maddy_smtp_username : String?,
         @maddy_smtp_password : String?,
         @maddy_from_email : String?,
-        @maddy_from_name : String?
+        @maddy_from_name : String?,
+        @repositories_enabled : Bool
       )
       end
 
       def self.load : Config
         raw = load_json_config
+        features = raw["features"]?.try(&.as_h) || Hash(String, JSON::Any).new
         backend = raw["backend"]?.try(&.as_h) || Hash(String, JSON::Any).new
         origins = raw["origins"]?.try(&.as_h) || Hash(String, JSON::Any).new
         payment = raw["payment"]?.try(&.as_h) || Hash(String, JSON::Any).new
@@ -112,7 +115,8 @@ module Crater
           maddy_smtp_username: read_env_or_optional_string("MADDY_SMTP_USERNAME", email_auth, "smtpUsername"),
           maddy_smtp_password: read_env_or_optional_string("MADDY_SMTP_PASSWORD", email_auth, "smtpPassword"),
           maddy_from_email: read_env_or_optional_string("MADDY_FROM_EMAIL", email_auth, "fromEmail"),
-          maddy_from_name: read_env_or_optional_string("MADDY_FROM_NAME", email_auth, "fromName")
+          maddy_from_name: read_env_or_optional_string("MADDY_FROM_NAME", email_auth, "fromName"),
+          repositories_enabled: read_env_or_bool("KEFINE_FEATURE_REPOSITORIES", features, "repositories", true)
         )
       end
 
@@ -168,6 +172,33 @@ module Crater
         source[key]?.try(&.raw).try { |value| value.is_a?(Int64) ? value : value.is_a?(Int32) ? value.to_i64 : nil } || fallback
       end
 
+      private def self.read_env_or_bool(env_key : String, source : Hash(String, JSON::Any), key : String, fallback : Bool) : Bool
+        value = ENV[env_key]?.try(&.strip)
+        return parse_bool(value.not_nil!, fallback) unless value.nil? || value.empty?
+
+        raw = source[key]?.try(&.raw)
+        parse_bool(raw, fallback)
+      end
+
+      private def self.parse_bool(value, fallback : Bool) : Bool
+        case value
+        when Bool
+          value
+        when Int64
+          value != 0
+        when Float64
+          value != 0.0
+        when String
+          normalized = value.strip.downcase
+          return fallback if normalized.empty?
+          return true if {"true", "1", "yes", "on", "enabled"}.includes?(normalized)
+          return false if {"false", "0", "no", "off", "disabled"}.includes?(normalized)
+          fallback
+        else
+          fallback
+        end
+      end
+
       private def self.load_json_config : Hash(String, JSON::Any)
         config_path = find_config_path
         return Hash(String, JSON::Any).new unless config_path
@@ -220,6 +251,15 @@ module Crater
 
       def resolved_actor_private_key_pem : String
         actor_private_key
+      end
+
+      def feature_enabled?(feature : String) : Bool
+        case feature
+        when "repositories"
+          repositories_enabled
+        else
+          true
+        end
       end
     end
   end

--- a/e2e/helpers/kefine.ts
+++ b/e2e/helpers/kefine.ts
@@ -116,6 +116,10 @@ export async function mockOrderApi(page: Page) {
   const orders = new Map<string, MockOrder>();
   let createDelayMs = 0;
 
+  await page.route('**/api/health', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+  });
+
   await page.route('**/create', async (route) => {
     createCounter += 1;
     const postData = route.request().postDataJSON() as { title?: string; name?: string };
@@ -200,7 +204,7 @@ export async function mockOrderApi(page: Page) {
     });
   }
 
-  await page.route('**/order/**', handleOrderLookup);
+  await page.route('**/api/order/**', handleOrderLookup);
   await page.route('**/status/**', handleOrderLookup);
 
   return {
@@ -265,6 +269,28 @@ export async function submitTask(page: Page) {
 export async function createTask(page: Page, title: string) {
   await page.getByTestId('kefine-task-input').fill(title);
   await submitTask(page);
+  const routeId = await page.waitForFunction<string | null, string>((taskTitle) => {
+    const raw = window.localStorage.getItem('kefine-created-orders-v1');
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      const orders = JSON.parse(raw) as Array<{ id?: string; shareId?: string; title?: string }>;
+      const order = orders.find((item) => {
+        const id = item.id ?? '';
+        return item.title === taskTitle && id && !id.startsWith('temp-') && !id.startsWith('local-');
+      });
+      return order ? (order.shareId || order.id) : null;
+    } catch {
+      return null;
+    }
+  }, title);
+  const routeValue = await routeId.jsonValue();
+  if (!routeValue) {
+    throw new Error(`Created task "${title}" was not written to local storage.`);
+  }
+  await page.goto(`/order/${encodeURIComponent(routeValue)}`);
 }
 
 export async function mockPrivateKeyAuth(page: Page) {

--- a/kefine.config.json
+++ b/kefine.config.json
@@ -10,6 +10,9 @@
       "hy": "Մարտ 2026"
     }
   },
+  "features": {
+    "repositories": false
+  },
   "backend": {
     "craterBaseUrl": "http://127.0.0.1:3001",
     "exchangeBaseUrl": "https://problemsets.lefine.pro",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
         command: `pnpm dev --host 127.0.0.1 --port ${PORT}`,
         port: PORT,
         reuseExistingServer: !process.env.CI,
-        timeout: 120000
+        timeout: 120000,
+        env: { KEFINE_FEATURE_REPOSITORIES: 'true' }
       },
   projects: [
     {

--- a/scripts/crater-smoke.sh
+++ b/scripts/crater-smoke.sh
@@ -47,3 +47,30 @@ for payload in responses:
     assert "@context" not in payload, payload
     assert payload.get("error") is None, payload
 PY
+
+vcs_create_response="$(curl -fsS \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"CI repository-disabled order","content":"CI repository-disabled order","vcsEnabled":true}' \
+  http://127.0.0.1:3001/create)"
+
+vcs_order_id="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["orderId"])' <<<"$vcs_create_response")"
+vcs_status_response="$(curl -fsS "http://127.0.0.1:3001/status?id=${vcs_order_id}")"
+vcs_settings_response="$(curl -fsS \
+  -X PATCH \
+  -H 'Content-Type: application/json' \
+  -d '{"vcsEnabled":true}' \
+  "http://127.0.0.1:3001/status/${vcs_order_id}/settings")"
+
+python3 - "$vcs_order_id" "$vcs_create_response" "$vcs_status_response" "$vcs_settings_response" <<'PY'
+import json
+import sys
+
+order_id = sys.argv[1]
+responses = [json.loads(value) for value in sys.argv[2:]]
+
+for payload in responses:
+    assert payload.get("orderId") == order_id, payload
+    assert payload.get("vcsEnabled") is False, payload
+    assert payload.get("projectId") in (None, ""), payload
+    assert payload.get("repository") is None, payload
+PY

--- a/src/lib/components/kefine/KefineExecutingStep.svelte
+++ b/src/lib/components/kefine/KefineExecutingStep.svelte
@@ -50,6 +50,7 @@
     walletNetworkLabel,
     canSaveCloneLocally = false,
     canManageTask = false,
+    repositoriesEnabled = true,
     isConfirmingStep = false,
     commentSubmittingStepId = null,
     confirmCurrentStepLabel,
@@ -125,6 +126,7 @@
     walletNetworkLabel: string;
     canSaveCloneLocally?: boolean;
     canManageTask?: boolean;
+    repositoriesEnabled?: boolean;
     isConfirmingStep?: boolean;
     commentSubmittingStepId?: string | null;
     confirmCurrentStepLabel?: string;
@@ -512,12 +514,17 @@
         <button type="button" class="kefine-flow-back" onclick={onCancel} aria-label={labels.cancel}>←</button>
         <lefine-box class="kefine-flow-topline-actions">
           {#if currentOrder && onUpdateTaskSettings}
-            <KefineTaskSettingsMenu order={currentOrder} onApply={onUpdateTaskSettings} />
+            <KefineTaskSettingsMenu
+              order={currentOrder}
+              repositoriesEnabled={repositoriesEnabled}
+              onApply={onUpdateTaskSettings}
+            />
           {/if}
           {#if currentOrder && onExportClone}
             <KefineTaskCloneMenu
               order={currentOrder}
               canSaveLocally={canSaveCloneLocally}
+              repositoriesEnabled={repositoriesEnabled}
               onExport={onExportClone}
               onSaveLocally={onSaveCloneLocally ?? undefined}
             />
@@ -728,6 +735,7 @@
         {historyOrders}
         canSaveCloneLocally={canSaveCloneLocally}
         canManageTask={canManageTask}
+        repositoriesEnabled={repositoriesEnabled}
         {commentSubmittingStepId}
         onSubmitStepComment={onSubmitStepComment}
         onSaveDocument={onSaveDocument}

--- a/src/lib/components/kefine/KefineTaskCloneMenu.svelte
+++ b/src/lib/components/kefine/KefineTaskCloneMenu.svelte
@@ -14,11 +14,13 @@
   let {
     order,
     canSaveLocally = false,
+    repositoriesEnabled = true,
     onExport,
     onSaveLocally
   }: {
     order: OrderView | null;
     canSaveLocally?: boolean;
+    repositoriesEnabled?: boolean;
     onExport: (format: TaskCloneFormat) => void;
     onSaveLocally?: (runLocally: boolean) => void;
   } = $props();
@@ -31,10 +33,10 @@
   const localeText = $derived($kefineLocaleText);
   const labels = $derived(localeText.solversView);
 
-  const repository = $derived(order ? getTaskRepository(order) : null);
-  const repositoryCloneTarget = $derived(order ? getTaskRepositoryCloneTarget(order) : null);
-  const repositoryLinkTarget = $derived(order ? getTaskRepositoryLinkTarget(order) : null);
-  const repositoryArchiveTargets = $derived(order ? getTaskRepositoryArchiveTargets(order) : null);
+  const repository = $derived(repositoriesEnabled && order ? getTaskRepository(order) : null);
+  const repositoryCloneTarget = $derived(repositoriesEnabled && order ? getTaskRepositoryCloneTarget(order) : null);
+  const repositoryLinkTarget = $derived(repositoriesEnabled && order ? getTaskRepositoryLinkTarget(order) : null);
+  const repositoryArchiveTargets = $derived(repositoriesEnabled && order ? getTaskRepositoryArchiveTargets(order) : null);
   const repositoryArchiveActions = $derived.by(() =>
     repositoryArchiveTargets
       ? [

--- a/src/lib/components/kefine/KefineTaskSettingsMenu.svelte
+++ b/src/lib/components/kefine/KefineTaskSettingsMenu.svelte
@@ -7,9 +7,11 @@
 
   let {
     order,
+    repositoriesEnabled = true,
     onApply
   }: {
     order: OrderView | null;
+    repositoriesEnabled?: boolean;
     onApply: (patch: Partial<Pick<OrderView, 'title' | 'description' | 'taskIcon' | 'shareId' | 'isPublicTask' | 'vcsEnabled' | 'repository'>> & {
       gitSettings?: RepositoryGitSettings;
     }) => void | Promise<void>;
@@ -225,7 +227,7 @@
               <Icon icon="mdi:close" width="18" height="18" aria-hidden="true" />
             </button>
           </kefine-task-settings-head>
-          {#if !vcsEnabledDraft && !order.repository}
+          {#if repositoriesEnabled && !vcsEnabledDraft && !order.repository}
             <button type="button" data-part="secondary" data-kind="create-repo" onclick={createGitRepo}>
               <Icon icon="mdi:source-repository" width="16" height="16" aria-hidden="true" />
               <lefine-text>{labels.createGitRepo}</lefine-text>
@@ -250,12 +252,14 @@
             <input bind:checked={isPublicDraft} type="checkbox" />
             <lefine-text>{labels.makePublic}</lefine-text>
           </label>
-          <label data-part="toggle">
-            <input bind:checked={vcsEnabledDraft} type="checkbox" />
-            <lefine-text>{labels.enableVcs}</lefine-text>
-          </label>
+          {#if repositoriesEnabled}
+            <label data-part="toggle">
+              <input bind:checked={vcsEnabledDraft} type="checkbox" />
+              <lefine-text>{labels.enableVcs}</lefine-text>
+            </label>
+          {/if}
 
-          {#if vcsEnabledDraft}
+          {#if repositoriesEnabled && vcsEnabledDraft}
             <kefine-task-settings-git>
               <strong>{labels.gitAccess}</strong>
               <label data-part="toggle">

--- a/src/lib/components/kefine/KefineTaskTreeFeed.svelte
+++ b/src/lib/components/kefine/KefineTaskTreeFeed.svelte
@@ -52,6 +52,7 @@
     labels,
     canSaveCloneLocally = false,
     canManageTask = false,
+    repositoriesEnabled = true,
     commentSubmittingStepId = null,
     onSubmitStepComment,
     onSaveDocument,
@@ -94,6 +95,7 @@
   };
     canSaveCloneLocally?: boolean;
     canManageTask?: boolean;
+    repositoriesEnabled?: boolean;
     commentSubmittingStepId?: string | null;
     onSubmitStepComment?: ((stepId: string, content: string) => Promise<void> | void) | null;
     onSaveDocument?: ((content: string) => Promise<void> | void) | null;
@@ -1026,12 +1028,17 @@
         <KefineTaskCloneMenu
           order={currentOrder}
           canSaveLocally={canSaveCloneLocally}
+          repositoriesEnabled={repositoriesEnabled}
           onExport={onExportClone}
           onSaveLocally={onSaveCloneLocally ?? undefined}
         />
       {/if}
       {#if currentOrder && onUpdateTaskSettings}
-        <KefineTaskSettingsMenu order={currentOrder} onApply={onUpdateTaskSettings} />
+        <KefineTaskSettingsMenu
+          order={currentOrder}
+          repositoriesEnabled={repositoriesEnabled}
+          onApply={onUpdateTaskSettings}
+        />
       {/if}
     </kefine-thread-head-actions>
   </kefine-thread-head>

--- a/src/lib/components/kefine/KefineWorkspace.svelte
+++ b/src/lib/components/kefine/KefineWorkspace.svelte
@@ -2,7 +2,7 @@
   import { browser } from '$app/environment';
   import { goto, replaceState } from '$app/navigation';
   import { page } from '$app/state';
-  import { resolvePublicRuntimeConfig } from '$lib/config/public-config';
+  import { isFeatureEnabled, resolvePublicRuntimeConfig } from '$lib/config/public-config';
   import { isSpecialRuntimeOrigin } from '$lib/config/special-runtime';
   import { resolveOrderProxyBasePath } from '$lib/order-proxy-path';
   import { onMount } from 'svelte';
@@ -105,6 +105,7 @@
   } = $props();
   const localeText = $derived($kefineLocaleText);
   const runtimeConfig = $derived(resolvePublicRuntimeConfig(page.data.publicConfig));
+  const repositoriesEnabled = $derived(isFeatureEnabled('repositories', runtimeConfig));
   const activeLocale = $derived(readLocaleFromPathname(page.url.pathname) ?? 'en');
 
   function getNormalizedInitialOrderId() {
@@ -2359,12 +2360,19 @@
   }
 
   async function handleUpdateTaskSettings(
-    patch: Partial<Pick<OrderView, 'title' | 'description' | 'taskIcon' | 'shareId' | 'isPublicTask' | 'vcsEnabled' | 'repository'>> & {
+    rawPatch: Partial<Pick<OrderView, 'title' | 'description' | 'taskIcon' | 'shareId' | 'isPublicTask' | 'vcsEnabled' | 'repository'>> & {
       gitSettings?: import('./kefine-workflow').RepositoryGitSettings;
     }
   ) {
     if (!currentOrder) {
       return;
+    }
+
+    const patch = { ...rawPatch };
+    if (!repositoriesEnabled) {
+      delete patch.vcsEnabled;
+      delete patch.gitSettings;
+      delete patch.repository;
     }
 
     updateProfileTask(currentOrder.id, patch);
@@ -2860,6 +2868,7 @@
           execution={executionPresentation}
           canSaveCloneLocally={canSaveCurrentOrderLocally}
           canManageTask={canManageCurrentOrder}
+          repositoriesEnabled={repositoriesEnabled}
           isHydratingTitle={isHydratingRoute && !currentOrder?.title.trim()}
           isConfirmingStep={confirmStepLoading}
           commentSubmittingStepId={stepCommentLoadingId}

--- a/src/lib/config/kefine-config-features.test.ts
+++ b/src/lib/config/kefine-config-features.test.ts
@@ -1,0 +1,13 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { resolvePublicRuntimeConfig } from './public-config';
+
+describe('shipped kefine.config.json feature flags', () => {
+  test('disables the repositories feature by default', () => {
+    const configPath = path.resolve(process.cwd(), 'kefine.config.json');
+    const raw = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    const resolved = resolvePublicRuntimeConfig(raw);
+    expect(resolved.features.repositories).toBe(false);
+  });
+});

--- a/src/lib/config/public-config.test.ts
+++ b/src/lib/config/public-config.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import {
+  DEFAULT_FEATURE_FLAGS,
+  DEFAULT_PUBLIC_RUNTIME_CONFIG,
+  isFeatureEnabled,
+  normalizeFeatureFlags,
+  resolvePublicRuntimeConfig,
+  setBrowserPublicRuntimeConfig
+} from './public-config';
+
+describe('normalizeFeatureFlags', () => {
+  test('returns defaults for missing or invalid input', () => {
+    expect(normalizeFeatureFlags(undefined)).toEqual(DEFAULT_FEATURE_FLAGS);
+    expect(normalizeFeatureFlags(null)).toEqual(DEFAULT_FEATURE_FLAGS);
+    expect(normalizeFeatureFlags('nope')).toEqual(DEFAULT_FEATURE_FLAGS);
+    expect(normalizeFeatureFlags({})).toEqual(DEFAULT_FEATURE_FLAGS);
+  });
+
+  test('respects explicit repository flag booleans', () => {
+    expect(normalizeFeatureFlags({ repositories: false })).toEqual({ repositories: false });
+    expect(normalizeFeatureFlags({ repositories: true })).toEqual({ repositories: true });
+  });
+
+  test('coerces common truthy and falsy forms', () => {
+    expect(normalizeFeatureFlags({ repositories: 'false' }).repositories).toBe(false);
+    expect(normalizeFeatureFlags({ repositories: 'off' }).repositories).toBe(false);
+    expect(normalizeFeatureFlags({ repositories: 'disabled' }).repositories).toBe(false);
+    expect(normalizeFeatureFlags({ repositories: 0 }).repositories).toBe(false);
+    expect(normalizeFeatureFlags({ repositories: 'true' }).repositories).toBe(true);
+    expect(normalizeFeatureFlags({ repositories: 'yes' }).repositories).toBe(true);
+    expect(normalizeFeatureFlags({ repositories: 1 }).repositories).toBe(true);
+  });
+
+  test('falls back to defaults for unrecognized values', () => {
+    expect(normalizeFeatureFlags({ repositories: 'maybe' }).repositories).toBe(
+      DEFAULT_FEATURE_FLAGS.repositories
+    );
+    expect(normalizeFeatureFlags({ repositories: '' }).repositories).toBe(
+      DEFAULT_FEATURE_FLAGS.repositories
+    );
+  });
+});
+
+describe('resolvePublicRuntimeConfig feature flags', () => {
+  test('includes default feature flags when none are provided', () => {
+    expect(resolvePublicRuntimeConfig({}).features).toEqual(DEFAULT_FEATURE_FLAGS);
+  });
+
+  test('threads configured feature flags through public config', () => {
+    const config = resolvePublicRuntimeConfig({ features: { repositories: false } });
+    expect(config.features.repositories).toBe(false);
+  });
+});
+
+describe('isFeatureEnabled', () => {
+  afterEach(() => {
+    setBrowserPublicRuntimeConfig(DEFAULT_PUBLIC_RUNTIME_CONFIG);
+  });
+
+  test('reads from an explicitly provided config', () => {
+    const enabled = resolvePublicRuntimeConfig({ features: { repositories: true } });
+    const disabled = resolvePublicRuntimeConfig({ features: { repositories: false } });
+    expect(isFeatureEnabled('repositories', enabled)).toBe(true);
+    expect(isFeatureEnabled('repositories', disabled)).toBe(false);
+  });
+
+  test('defaults to the browser runtime config when no config is provided', () => {
+    setBrowserPublicRuntimeConfig({ features: { repositories: false } });
+    expect(isFeatureEnabled('repositories')).toBe(false);
+
+    setBrowserPublicRuntimeConfig({ features: { repositories: true } });
+    expect(isFeatureEnabled('repositories')).toBe(true);
+  });
+});

--- a/src/lib/config/public-config.ts
+++ b/src/lib/config/public-config.ts
@@ -23,10 +23,21 @@ export type KefineDefaultActorPublicConfig = {
   displayName: string;
 };
 
+export type KefineFeatureFlagId = 'repositories';
+
+export type KefineFeatureFlags = Record<KefineFeatureFlagId, boolean>;
+
+export const DEFAULT_FEATURE_FLAGS: KefineFeatureFlags = {
+  repositories: true
+};
+
+export const KEFINE_FEATURE_FLAG_IDS = Object.keys(DEFAULT_FEATURE_FLAGS) as KefineFeatureFlagId[];
+
 export type KefinePublicRuntimeConfig = {
   app: KefinePublicAppConfig;
   services: KefinePinnedServiceConfig[];
   defaultActor: KefineDefaultActorPublicConfig;
+  features: KefineFeatureFlags;
   backend: {
     craterBaseUrl: string;
   };
@@ -55,6 +66,7 @@ export const DEFAULT_PUBLIC_RUNTIME_CONFIG: KefinePublicRuntimeConfig = {
     handle: 'staff',
     displayName: 'Staff'
   },
+  features: { ...DEFAULT_FEATURE_FLAGS },
   backend: {
     craterBaseUrl: 'http://localhost:3001'
   }
@@ -62,6 +74,40 @@ export const DEFAULT_PUBLIC_RUNTIME_CONFIG: KefinePublicRuntimeConfig = {
 
 export function normalizeText(value: unknown, fallback = ''): string {
   return typeof value === 'string' ? value.trim() || fallback : fallback;
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+      return fallback;
+    }
+    if (['true', '1', 'yes', 'on', 'enabled'].includes(normalized)) {
+      return true;
+    }
+    if (['false', '0', 'no', 'off', 'disabled'].includes(normalized)) {
+      return false;
+    }
+  }
+
+  return fallback;
+}
+
+export function normalizeFeatureFlags(value: unknown): KefineFeatureFlags {
+  const source = value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+  const features = {} as KefineFeatureFlags;
+
+  for (const id of KEFINE_FEATURE_FLAG_IDS) {
+    features[id] = normalizeBoolean(source[id], DEFAULT_FEATURE_FLAGS[id]);
+  }
+
+  return features;
 }
 
 export function resolvePublicRuntimeConfig(value: unknown): KefinePublicRuntimeConfig {
@@ -73,6 +119,7 @@ export function resolvePublicRuntimeConfig(value: unknown): KefinePublicRuntimeC
     app?: Partial<KefinePublicAppConfig>;
     services?: unknown;
     defaultActor?: Partial<KefineDefaultActorPublicConfig>;
+    features?: unknown;
   };
   const app: Partial<KefinePublicAppConfig> = source.app ?? {};
   const defaultActor: Partial<KefineDefaultActorPublicConfig> = source.defaultActor ?? {};
@@ -112,6 +159,7 @@ export function resolvePublicRuntimeConfig(value: unknown): KefinePublicRuntimeC
       handle: normalizeText(defaultActor.handle, DEFAULT_PUBLIC_RUNTIME_CONFIG.defaultActor.handle),
       displayName: normalizeText(defaultActor.displayName, DEFAULT_PUBLIC_RUNTIME_CONFIG.defaultActor.displayName)
     },
+    features: normalizeFeatureFlags(source.features),
     backend: {
       craterBaseUrl: normalizeText((value as { backend?: { craterBaseUrl?: string } }).backend?.craterBaseUrl, DEFAULT_PUBLIC_RUNTIME_CONFIG.backend.craterBaseUrl)
     }
@@ -130,4 +178,11 @@ export function setBrowserPublicRuntimeConfig(value: unknown): void {
 
 export function readBrowserPublicRuntimeConfig(): KefinePublicRuntimeConfig {
   return browserPublicRuntimeConfig ?? DEFAULT_PUBLIC_RUNTIME_CONFIG;
+}
+
+export function isFeatureEnabled(
+  feature: KefineFeatureFlagId,
+  config: KefinePublicRuntimeConfig = readBrowserPublicRuntimeConfig()
+): boolean {
+  return config.features[feature] !== false;
 }

--- a/src/lib/server/kefine-config.ts
+++ b/src/lib/server/kefine-config.ts
@@ -2,9 +2,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {
   DEFAULT_PUBLIC_RUNTIME_CONFIG,
+  KEFINE_FEATURE_FLAG_IDS,
+  normalizeFeatureFlags,
   normalizeText,
   resolvePublicRuntimeConfig,
   type KefineDefaultActorPublicConfig,
+  type KefineFeatureFlags,
   type KefinePinnedServiceConfig,
   type KefinePublicRuntimeConfig
 } from '$lib/config/public-config';
@@ -15,6 +18,7 @@ type KefineFullConfig = {
   defaultActor: KefineDefaultActorPublicConfig & {
     privateKey: string;
   };
+  features: KefineFeatureFlags;
   backend: {
     craterBaseUrl: string;
     exchangeBaseUrl: string;
@@ -40,6 +44,7 @@ const DEFAULT_CONFIG: KefineFullConfig = {
     ...DEFAULT_PUBLIC_RUNTIME_CONFIG.defaultActor,
     privateKey: ''
   },
+  features: DEFAULT_PUBLIC_RUNTIME_CONFIG.features,
   backend: {
     craterBaseUrl: 'http://localhost:3001',
     exchangeBaseUrl: 'http://localhost:3001',
@@ -81,6 +86,17 @@ function readEnvironmentOverride(name: string): string {
   return normalizeText(process.env[name]);
 }
 
+function applyFeatureFlagEnvOverrides(base: KefineFeatureFlags): KefineFeatureFlags {
+  const resolved = { ...base };
+  for (const id of KEFINE_FEATURE_FLAG_IDS) {
+    const override = readEnvironmentOverride(`KEFINE_FEATURE_${id.toUpperCase()}`);
+    if (override) {
+      resolved[id] = normalizeFeatureFlags({ [id]: override })[id];
+    }
+  }
+  return resolved;
+}
+
 export function getKefineConfig(): KefineFullConfig {
   if (cachedConfig) {
     return cachedConfig;
@@ -91,7 +107,8 @@ export function getKefineConfig(): KefineFullConfig {
   const publicConfig = resolvePublicRuntimeConfig({
     app: objectSource.app,
     services: objectSource.services,
-    defaultActor: objectSource.defaultActor
+    defaultActor: objectSource.defaultActor,
+    features: objectSource.features
   });
   const defaultActor = (objectSource.defaultActor ?? {}) as Record<string, unknown>;
   const backend = (objectSource.backend ?? {}) as Record<string, unknown>;
@@ -100,6 +117,7 @@ export function getKefineConfig(): KefineFullConfig {
   cachedConfig = {
     app: publicConfig.app,
     services: publicConfig.services,
+    features: applyFeatureFlagEnvOverrides(publicConfig.features),
     defaultActor: {
       handle: publicConfig.defaultActor.handle,
       displayName: publicConfig.defaultActor.displayName,
@@ -150,6 +168,7 @@ export function getPublicRuntimeConfig(): KefinePublicRuntimeConfig {
       handle: config.defaultActor.handle,
       displayName: config.defaultActor.displayName
     },
+    features: config.features,
     backend: {
       craterBaseUrl: config.backend.craterBaseUrl
     }


### PR DESCRIPTION
## Summary

Fixes #99.

- Adds a `features.repositories` flag to public/server config, with `KEFINE_FEATURE_REPOSITORIES` as a process-level override.
- Disables repository controls in the Svelte UI when the flag is off, including VCS settings, git access controls, and repository clone/archive entries.
- Disables Crater repository/project/git/ForgeFed/SSH-key routes and guards repository-store operations when repositories are disabled.
- Updates docs, default `kefine.config.json`, Crater smoke assertions, and feature-flag tests.

## Reproduction and Verification

- `src/lib/config/kefine-config-features.test.ts` verifies the shipped config disables repositories by default.
- `src/lib/config/public-config.test.ts` verifies feature flag defaults, coercion, runtime resolution, and `isFeatureEnabled`.
- `scripts/crater-smoke.sh` now sends `vcsEnabled: true` while repositories are disabled and asserts the API returns `vcsEnabled: false` with no repository/project payload.

## Checks

- `pnpm test` passed: 15 files, 106 tests.
- `pnpm check` passed with 0 errors and existing Svelte warnings.
- `pnpm lint` passed with 0 errors and existing warnings.
- `pnpm build` passed.
- `cd crater && crystal build --no-codegen src/crater.cr -o /tmp/kefine-crater-check` passed.
- `pnpm test:e2e e2e/task-clone.spec.ts` passed: 4 tests.

## Notes

- Local `./scripts/crater-smoke.sh` could not run here because no Docker Compose-compatible runtime is installed; the script itself was updated for CI coverage.
- Full local `pnpm test:e2e` still has broader existing failures: 16 passed, 34 failed in auth/lifecycle specs that look for ProseKit branch controls or auth endpoints. The repository clone spec passes.
- I attempted to merge `origin/release` into this prepared branch, but the branch base diverges and produced unrelated conflicts. I left the branch on the prepared PR base.
