### PR TITLE
Fix sign-in button recovery after auth load failure

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-31T12:45:09.160Z for PR creation at branch issue-110-becb65f8fc26 for issue https://github.com/lefinepro/kefine/issues/110

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-31T12:45:09.160Z for PR creation at branch issue-110-becb65f8fc26 for issue https://github.com/lefinepro/kefine/issues/110

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -33,4 +33,21 @@ line-2
     await page.getByTestId('kefine-privatekey-input').fill(pemKey);
     await expect(page.getByTestId('kefine-privatekey-input')).toHaveValue(pemKey);
   });
+
+  test('sign in button recovers when the auth drawer lazy load fails', async ({ page }) => {
+    await gotoAndWaitForReady(page);
+
+    let blockedAuthDrawerModule = false;
+    await page.route(/\/src\/lib\/components\/kefine\/KefineAuthDialog\.svelte(?:\?|$)/, async (route) => {
+      blockedAuthDrawerModule = true;
+      await route.abort('failed');
+    });
+
+    const authButton = page.locator("button[data-part='auth']");
+    await authButton.click();
+
+    await expect.poll(() => blockedAuthDrawerModule).toBe(true);
+    await expect(authButton).toBeEnabled();
+    await expect(authButton).toHaveAttribute('data-loading', 'false');
+  });
 });

--- a/src/lib/components/kefine/KefineWorkspace.svelte
+++ b/src/lib/components/kefine/KefineWorkspace.svelte
@@ -1335,13 +1335,19 @@
       authDialogOpen = false;
       return;
     }
+
     authButtonLoading = true;
-    await ensureDialogComponentsLoaded();
-    await tick();
-    await new Promise(r => requestAnimationFrame(r));
-    authDialogOpen = true;
-    await tick();
-    authButtonLoading = false;
+    try {
+      await ensureDialogComponentsLoaded();
+      await tick();
+      await new Promise(r => requestAnimationFrame(r));
+      authDialogOpen = true;
+      await tick();
+    } catch (error) {
+      console.error('[auth] selectTopbarAuth failed', error);
+    } finally {
+      authButtonLoading = false;
+    }
   }
 
   async function openTopbarProfile() {


### PR DESCRIPTION
Fixes #110

## Summary
- Reset the workspace auth button loading state in a `finally` block when the auth drawer lazy import fails.
- Log the failed auth drawer open attempt and leave the sign-in button enabled so the user can retry instead of being stuck on a spinner.
- Add a Playwright regression that blocks the auth drawer module and verifies the sign-in button recovers.

## Reproduction
1. Open the workspace.
2. Block the lazy-loaded `KefineAuthDialog.svelte` module, matching a stale long-lived tab or failed chunk load after deployment.
3. Click Sign in. Before this fix the button stayed disabled with `data-loading="true"`; after this fix it returns to enabled with `data-loading="false"`.

## Testing
- `pnpm check`
- `pnpm lint`
- `pnpm test`
- `pnpm test:integration`
- `pnpm build`
- `pnpm exec playwright test e2e/auth.spec.ts --project=chromium --project=mobile-chromium -g "sign in button recovers" --workers=1`

Note: full `e2e/auth.spec.ts` requires the local `actor-privatekey.pem` fixture, which is not present in this prepared workspace.