### PR TITLE
Fix Lepos dependency setup

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-06T16:03:41.786Z for PR creation at branch issue-154-6a7b2435e5b9 for issue https://github.com/lefinepro/kefine/issues/154
-# Updated: 2026-06-08T06:01:51.564Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-06T16:03:41.786Z for PR creation at branch issue-154-6a7b2435e5b9 for issue https://github.com/lefinepro/kefine/issues/154
+# Updated: 2026-06-08T06:01:51.564Z

--- a/README.md
+++ b/README.md
@@ -307,9 +307,9 @@ mise run dev
 This command:
 
 - ensures frontend dependencies are installed,
-- starts Postgres via `nerdctl compose`,
+- starts Postgres via Compose,
 - waits until the database is ready,
-- starts `crater` in a container on `http://localhost:3001`,
+- starts the Lepos backend in a container on `http://localhost:3001`,
 - starts the SvelteKit frontend on `http://localhost:5173`.
 
 You can also run just `mise run`, because the default task maps to `dev`.
@@ -370,7 +370,7 @@ If you do not want to use the one-command `mise` flow, you still have two practi
 Option A: run only the backend in a container
 
 ```bash
-nerdctl compose up --build crater
+./scripts/container-compose.sh up --build lepos
 ```
 
 Option B: run the backend directly with Crystal

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ depends = ["dev"]
 
 [tasks.install]
 description = "Install all project dependencies"
-depends = ["frontend:deps"]
+depends = ["frontend:deps", "backend:deps"]
 
 [tasks."frontend:deps"]
 description = "Install frontend dependencies with pnpm"
@@ -21,26 +21,28 @@ fi
 '''
 
 [tasks."backend:deps"]
-description = "Install crater dependencies with shards"
+description = "Install Lepos backend dependencies with shards"
 run = '''
-if [ ! -d crater/lib/kemal ]; then
-  cd crater && shards install
+cd crater
+if ! shards check >/dev/null 2>&1; then
+  shards install --frozen
 fi
+../scripts/patch-rcl-crystal-merge.sh
 '''
 
 [tasks."backend:build"]
-description = "Build the crater dev container image"
-run = "./scripts/nerdctl-compose.sh build crater"
+description = "Build the Lepos backend dev container image"
+run = "./scripts/container-compose.sh build lepos"
 
 [tasks."db:up"]
-description = "Start local Postgres in nerdctl compose"
-run = "./scripts/nerdctl-compose.sh up -d postgres"
+description = "Start local Postgres with Compose"
+run = "./scripts/container-compose.sh up -d postgres"
 
 [tasks."db:wait"]
 description = "Wait until local Postgres accepts connections"
 depends = ["db:up"]
 run = '''
-until ./scripts/nerdctl-compose.sh exec -T postgres pg_isready -U kefine -d kefine >/dev/null 2>&1; do
+until ./scripts/container-compose.sh exec -T postgres pg_isready -U kefine -d kefine >/dev/null 2>&1; do
   echo "Waiting for postgres on localhost:5432..."
   sleep 1
 done
@@ -52,7 +54,7 @@ run = "containerd-rootless-setuptool.sh install"
 
 [tasks."db:down"]
 description = "Stop local Postgres"
-run = "./scripts/nerdctl-compose.sh stop postgres"
+run = "./scripts/container-compose.sh stop postgres"
 
 [tasks.frontend]
 description = "Run the SvelteKit frontend"
@@ -70,21 +72,21 @@ depends = ["frontend:build"]
 run = "pnpm preview --host 0.0.0.0"
 
 [tasks.backend]
-description = "Run the crater backend in a dev container without rebuilding"
+description = "Run the Lepos backend in a dev container without rebuilding"
 depends = ["db:wait"]
-run = "./scripts/nerdctl-compose.sh up crater"
+run = "./scripts/container-compose.sh up lepos"
 
 [tasks."backend:local"]
-description = "Run the crater backend directly with Crystal"
+description = "Run the Lepos backend directly with Crystal"
 depends = ["backend:deps", "db:wait"]
 run = "cd crater && crystal run src/crater.cr"
 
 [tasks."backend:down"]
-description = "Stop the crater backend container"
-run = "./scripts/nerdctl-compose.sh stop crater"
+description = "Stop the Lepos backend container"
+run = "./scripts/container-compose.sh stop lepos"
 
 [tasks.dev]
-description = "Start Postgres, crater, and the frontend"
+description = "Start Postgres, Lepos, and the frontend"
 depends = ["install"]
 run = "mise run backend ::: frontend"
 
@@ -100,6 +102,6 @@ frpc -c scripts/frpc.dev-proxy.toml
 '''
 
 [tasks."dev:proxy"]
-description = "Start the local stack and expose it through FRP"
+description = "Start the local Lepos stack and expose it through FRP"
 depends = ["install"]
 run = "mise run backend ::: frontend ::: tunnel"


### PR DESCRIPTION
## Summary

Fixes the local Lepos/Crater setup path that could leave Aptok missing from a stale shard cache and then fail at:

```text
src/crater/aptok.cr:4:1
Error: can't find file 'aptok/portable'
```

## Root Cause

`mise run backend:local` depended on `backend:deps`, but `backend:deps` only checked whether `crater/lib/kemal` existed. If a developer had an older or partial `crater/lib` cache with Kemal present and Aptok absent, the task skipped `shards install` and Crystal failed on the first Aptok require.

## Changes

- Make `backend:deps` run `shards check` and install locked shards with `shards install --frozen` whenever the full shard set is not satisfied.
- Keep the RCL compatibility patch in the local dependency setup path.
- Use the repo's Compose wrapper and the actual `lepos` service name in mise backend/db tasks.
- Update README backend commands to match the current Compose service.
- Remove the bootstrap `.gitkeep` placeholder.

## Reproduction

Before the fix, I reproduced issue #158 by creating a stale `crater/lib` cache with `kemal` installed and `aptok` removed, then running the old `backend:deps` guard followed by `crystal build src/crater.cr --no-codegen`. It failed with the reported missing `aptok/portable` error at `src/crater/aptok.cr:4:1`.

## Verification

- Stale-cache reproduction with the patched `backend:deps` logic: passes and reinstalls Aptok.
- `./scripts/crater-smoke.sh`: passes.
- `git diff --check`: passes.

Fixes #158.